### PR TITLE
Extract table freeze optimizations from graphql-caching branch

### DIFF
--- a/packages/oc-pages/project_overview/store/modules/project_application_blueprint.js
+++ b/packages/oc-pages/project_overview/store/modules/project_application_blueprint.js
@@ -194,8 +194,8 @@ const actions = {
         for(const key of ordering) {
             const value = root[key]
             if(!value || typeof value != 'object') continue
-            if(typeof transforms[key] == 'function')
-                Object.values(value).forEach(entry => {if(typeof entry == 'object') {transforms[key](entry, root)}})
+            if(!Object.isFrozen(value) && typeof transforms[key] == 'function')
+                Object.values(value).forEach(entry => {if(typeof entry == 'object' && !Object.isFrozen(entry)) {transforms[key](entry, root)}})
             commit('setProjectState', {key, value})
         }
         if(root.ApplicationBlueprint) {

--- a/packages/oc-pages/vue_shared/client_utils/misc.js
+++ b/packages/oc-pages/vue_shared/client_utils/misc.js
@@ -1,3 +1,10 @@
 export function sleep(period) {
     return new Promise(resolve => setTimeout(resolve, period))
 }
+
+export const deepFreeze = obj => {
+  Object.keys(obj).forEach(prop => {
+    if (obj[prop] && typeof obj[prop] === 'object') deepFreeze(obj[prop]);
+  });
+  return Object.freeze(obj);
+};


### PR DESCRIPTION
Reduced lighthouse's total blocking time estimate by ~75%, but didn't seem to help as much with other metrics