### PR TITLE
Basic sharing and displaying shared resources

### DIFF
--- a/packages/oc-pages/dashboard/components/share-resource-toggle.vue
+++ b/packages/oc-pages/dashboard/components/share-resource-toggle.vue
@@ -1,0 +1,86 @@
+<script>
+import {mapGetters, mapActions} from 'vuex'
+import {DetectIcon} from 'oc_vue_shared/oc-components'
+import {GlDropdown, GlDropdownItem, GlDropdownDivider} from '@gitlab/ui'
+export default {
+    props: {
+        card: Object
+    },
+    components: {DetectIcon, GlDropdown, GlDropdownItem, GlDropdownDivider},
+    computed: {
+        ...mapGetters(['getCurrentEnvironment', 'getDeploymentTemplate', 'getResourceSharedState', 'getHomeProjectPath']),
+        canShareResource() {
+            return this.card?.name && !this.card.name.startsWith('__')
+        },
+        sharedStatus() {
+            return this.getResourceSharedState(this.getCurrentEnvironment.name,  this.getDeploymentTemplate.name, this.card.name)
+        },
+        dropdownText() {
+            if( this.sharedStatus ) {
+                return 'Shared'
+            }
+            return 'Share'
+        },
+        sharedWithText() {
+            if(this.sharedStatus == 'dashboard') {
+                return `Currently shared with deployments in all dashboard environments.`
+            }
+            else if(this.sharedStatus == 'environment') {
+                return `Currently shared with deployments in <b>${this.getCurrentEnvironment.name}</b>.`
+            }
+            return ''
+        }
+    },
+    methods: {
+        ...mapActions(['updateResourceSharedState', 'unshareResource']),
+        shareWithEnvironment() {
+            const 
+                environmentName = this.getCurrentEnvironment.name,
+                deploymentName = this.getDeploymentTemplate.name,
+                resourceName = this.card.name,
+                shareState = 'environment'
+        
+            this.updateResourceSharedState({environmentName, deploymentName, resourceName, shareState})
+        },
+        shareWithDashboard() {
+            const 
+                environmentName = this.getCurrentEnvironment.name,
+                deploymentName = this.getDeploymentTemplate.name,
+                resourceName = this.card.name,
+                shareState = 'dashboard'
+
+            this.updateResourceSharedState({environmentName, deploymentName, resourceName, shareState})
+        },
+        stopSharing() {
+            const 
+                environmentName = this.getCurrentEnvironment.name,
+                deploymentName = this.getDeploymentTemplate.name,
+                resourceName = this.card.name
+
+            this.unshareResource({environmentName, deploymentName, resourceName})
+        }
+    }
+}
+
+</script>
+<template>
+
+    <gl-dropdown v-if="canShareResource" style="margin: 0 -0.5em;" toggle-class="text-decoration-none" no-caret right :popper-opts="{ positionFixed: true }">
+        <template #header v-if="sharedStatus">
+            <div>
+                <div style="padding: 0 1rem" v-html="sharedWithText" />
+                <gl-dropdown-divider />
+            </div>
+        </template>
+        <template #button-content>
+            <div class="d-flex">
+                <detect-icon name="share" :size="18" /> <span>{{dropdownText}}</span>
+            </div>
+        </template>
+        <gl-dropdown-item v-if="sharedStatus != 'environment'" @click="shareWithEnvironment">
+            <div class="d-inline-flex">Share with deployments in only the current environment</div>
+        </gl-dropdown-item>
+        <gl-dropdown-item v-if="sharedStatus != 'dashboard'" @click="shareWithDashboard">Share with all environments in the current dashboard</gl-dropdown-item>
+        <gl-dropdown-item v-if="sharedStatus" @click="stopSharing">Stop sharing <b>{{card.title}}</b></gl-dropdown-item>
+    </gl-dropdown>
+</template>

--- a/packages/oc-pages/dashboard/pages/deployment.vue
+++ b/packages/oc-pages/dashboard/pages/deployment.vue
@@ -2,6 +2,7 @@
 import {mapGetters, mapActions} from 'vuex'
 import DeploymentResources from 'oc_vue_shared/components/oc/deployment-resources.vue'
 import DashboardBreadcrumbs from '../components/dashboard-breadcrumbs.vue'
+import ShareResourceToggle from '../components/share-resource-toggle.vue'
 import {bus} from 'oc_vue_shared/bus'
 import * as routes from '../router/constants'
 import {cloneDeep} from 'lodash'
@@ -15,7 +16,7 @@ import {notFoundError} from 'oc_vue_shared/client_utils/error'
 import {DeploymentIndexTable} from 'oc_dashboard/components'
 
 export default {
-    components: {DeploymentResources, DashboardBreadcrumbs, ConsoleWrapper, GlTabs, OcTab, DeploymentIndexTable},
+    components: {DeploymentResources, DashboardBreadcrumbs, ConsoleWrapper, GlTabs, OcTab, DeploymentIndexTable, ShareResourceToggle},
     data() {
         const environmentName = this.$route.params.environment
         const deploymentName = this.$route.params.name
@@ -151,7 +152,11 @@ export default {
             <oc-tab title="Deployment" />
             <oc-tab v-show="jobsData" title="Console" />
         </gl-tabs>
-        <deployment-resources ref="deploymentResources" v-show="currentTab == 0" v-if="viewReady" :custom-title="deployment.title" :display-validation="false" :display-status="true" :readonly="true" :bus="bus" />
+        <deployment-resources ref="deploymentResources" v-show="currentTab == 0" v-if="viewReady" :custom-title="deployment.title" :display-validation="false" :display-status="true" :readonly="true" :bus="bus">
+            <template #controls="card">
+                <share-resource-toggle :card="card" />
+            </template>
+        </deployment-resources>
         <console-wrapper v-show="currentTab == 1" ref="consoleWrapper" @active-deployment="setTabToConsoleIfNeeded" v-if="jobsData" :jobs-data="jobsData" />
     </div>
 </template>

--- a/packages/oc-pages/project_overview/components/main.vue
+++ b/packages/oc-pages/project_overview/components/main.vue
@@ -18,8 +18,13 @@ export default {
 
         this.$store.dispatch('populateCurrentUser').catch(() => {})
 
-        if(this.$route.params.dashboard) {
-          this.$store.commit('setCurrentNamespace', this.$route.params.dashboard.split('/').slice(0, -1).join('/'))
+        let dashboard
+        if(dashboard = this.$route.params.dashboard) {
+          dashboard = decodeURIComponent(dashboard)
+
+          const namespace = dashboard.split('/').slice(0, -1).join('/')
+          console.log({namespace})
+          this.$store.commit('setCurrentNamespace', namespace)
         }
 
         errorContext = 'ocFetchEnvironments'
@@ -33,6 +38,8 @@ export default {
                     projectPath: this.$projectGlobal?.projectPath
                 });
             })
+
+        this.$store.dispatch('loadAdditionalDashboards')
 
         try {
             const {projectPath} = this.$projectGlobal

--- a/packages/oc-pages/project_overview/components/shared/oc_card.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_card.vue
@@ -180,7 +180,7 @@ export default {
                 </div>
 
                 <div class="d-flex align-items-center">
-                    <slot name="controls">
+                    <slot name="controls" v-bind="card">
                         <gl-button v-if="card && !isPrimary && !readonly && !card._permanent" @click="openDeletemodal" class="controls">
                             <div class="d-flex align-items-center">
                                 <gl-icon name="remove" />
@@ -255,6 +255,7 @@ export default {
 
 .card-toggle {
     margin-left: 0.5em;
+    display: inline-flex;
 }
 
 @media only screen and (max-width: 768px) {

--- a/packages/oc-pages/project_overview/components/shared/oc_card.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_card.vue
@@ -126,6 +126,10 @@ export default {
             return {name, size, 'class': className, title, isProtected}
         },
 
+        _readonly() {
+            return this.readonly || this.card?.imported
+        }
+
     },
     methods: {
 
@@ -181,7 +185,7 @@ export default {
 
                 <div class="d-flex align-items-center">
                     <slot name="controls" v-bind="card">
-                        <gl-button v-if="card && !isPrimary && !readonly && !card._permanent" @click="openDeletemodal" class="controls">
+                        <gl-button v-if="card && !isPrimary && !_readonly && !card._permanent" @click="openDeletemodal" class="controls">
                             <div class="d-flex align-items-center">
                                 <gl-icon name="remove" />
                                 <div> {{__('Remove')}} </div>

--- a/packages/oc-pages/project_overview/components/shared/oc_template_header.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_template_header.vue
@@ -31,7 +31,10 @@ export default {
     },
     methods: {
       returnHome() {
-        this.$router.push({name: 'projectHome', slug: this.$route.params.slug})
+        // TODO re-enable this when we're able to update the current namespace 
+        // https://github.com/onecommons/gitlab-oc/issues/867
+        // this.$router.push({name: 'projectHome', slug: this.$route.params.slug})
+        window.location.href = this.$router.resolve({name: 'projectHome', slug: this.$route.params.slug}).href
       }
     }
 }

--- a/packages/oc-pages/project_overview/components/shared/oc_template_header.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_template_header.vue
@@ -3,6 +3,7 @@ import { __ } from '~/locale';
 import {DetectIcon} from 'oc_vue_shared/oc-components'
 import {mapGetters} from 'vuex'
 import {ProjectIcon} from 'oc_vue_shared/oc-components'
+import {projectPathToHomeRoute} from 'oc_vue_shared/client_utils/dashboard'
 
 export default {
     name: 'OcTemplateHeader',
@@ -22,6 +23,10 @@ export default {
           return 'local dev'
         }
         return this.getCurrentEnvironmentType
+      },
+      environmentURL() {
+          const homePath = projectPathToHomeRoute(decodeURIComponent(this.$route.params.dashboard))
+          return `${homePath}/-/environments/${this.getCurrentEnvironmentName}`
       }
     },
     methods: {
@@ -34,7 +39,7 @@ export default {
 <template>
     <div class="m-2 d-flex flex-wrap justify-content-between align-items-center">
         <h1 @click="returnHome" class="template-title m-0"> <project-icon style="font-size: 0.83em; margin-right: 0.5em;" :project-icon="getApplicationBlueprint.projectIcon" /> {{ getApplicationBlueprint.title }}</h1>
-        <a class="d-inline-flex align-items-center" :href="`/dashboard/environments/${getCurrentEnvironmentName}`" target="_blank">
+        <a class="d-inline-flex align-items-center" :href="environmentURL" target="_blank">
             <span class="gl-pl-2 oc_environment_name mr-2">{{ getCurrentEnvironmentName }}</span> 
             <detect-icon :size="18" :type="cloud" />
         </a>

--- a/packages/oc-pages/project_overview/components/template/template_buttons.vue
+++ b/packages/oc-pages/project_overview/components/template/template_buttons.vue
@@ -43,7 +43,10 @@ export default {
             if(decodeURIComponent(location.href.slice(location.origin.length)) == editingTarget) {
                 window.location.href = editingDraftFrom
             } else {
-                this.$router.push({name: 'projectHome', slug: this.$route.params.slug})
+                // TODO re-enable this when we're able to update the current namespace 
+                // https://github.com/onecommons/gitlab-oc/issues/867
+                // this.$router.push({name: 'projectHome', slug: this.$route.params.slug})
+                window.location.href = this.$router.resolve({name: 'projectHome', slug: this.$route.params.slug}).href
             }
         }
     },

--- a/packages/oc-pages/project_overview/graphql/mutations/update_deployment_object.graphql
+++ b/packages/oc-pages/project_overview/graphql/mutations/update_deployment_object.graphql
@@ -1,4 +1,4 @@
-mutation UpdateDeploymentObject($fullPath: ID!, $patch: JSON!, $path: String!) {
-  updateDeploymentObj(input: {projectPath: $fullPath, patch: $patch, path: $path}) {isOk, errors}
+mutation UpdateDeploymentObject($fullPath: ID!, $patch: JSON!, $path: String!, $commitMessage: String) {
+  updateDeploymentObj(input: {projectPath: $fullPath, patch: $patch, path: $path, commitMsg: $commitMessage}) {isOk, errors}
 }
 

--- a/packages/oc-pages/project_overview/pages/projects/index.vue
+++ b/packages/oc-pages/project_overview/pages/projects/index.vue
@@ -190,7 +190,7 @@ export default {
         defaultEnvironmentName: {
             immediate: true,
             handler(val) {
-                if(!this.selectedEnvironment) this.selectedEnvironment = val
+                if(!this.selectedEnvironment) this.selectedEnvironment = this.lookupEnvironment(val)
             }
         }
     },
@@ -232,7 +232,7 @@ export default {
             this.triedPopulatingDeploymentItems = true
             this.populateDeploymentItems(this.yourDeployments)
         }
-        this.selectedEnvironment = this.$route.query?.env || sessionStorage['instantiate_env']
+        this.selectedEnvironment = this.lookupEnvironment(this.$route.query?.env || sessionStorage['instantiate_env'])
         this.newEnvironmentProvider = this.$route.query?.provider || sessionStorage['instantiate_provider']
 
         const templateSelected = this.$route.query?.ts?
@@ -247,7 +247,8 @@ export default {
         redirectToTemplateEditor(page=routes.OC_PROJECT_VIEW_CREATE_TEMPLATE) {
             const query = this.$route.query || {}
             if(Object.keys(query).length != 0) this.$router.replace({query: {}})
-            this.$router.push({ query, name: page, params: { dashboard: encodeURIComponent(this.getHomeProjectPath),environment: this.templateSelected.environment, slug: this.templateSelected.name}});
+            const dashboard = encodeURIComponent(this.selectedEnvironment._dashboard || this.getHomeProjectPath)
+            this.$router.push({ query, name: page, params: { dashboard, environment: this.templateSelected.environment, slug: this.templateSelected.name}});
         },
 
         clearModalTemplate(e) {
@@ -335,7 +336,7 @@ export default {
             this.templateSelected.title = this.templateForkedName;
             this.templateSelected.name = slugify(this.templateForkedName);
             this.templateSelected.totalDeployments = 0;
-            this.templateSelected.environment = this.selectedEnvironment || this.defaultEnvironmentName
+            this.templateSelected.environment = this.selectedEnvironment?.name || this.defaultEnvironmentName
             this.templateSelected.primaryType = this.getProjectInfo.primary
         },
 

--- a/packages/oc-pages/project_overview/pages/projects/index.vue
+++ b/packages/oc-pages/project_overview/pages/projects/index.vue
@@ -248,7 +248,10 @@ export default {
             const query = this.$route.query || {}
             if(Object.keys(query).length != 0) this.$router.replace({query: {}})
             const dashboard = encodeURIComponent(this.selectedEnvironment._dashboard || this.getHomeProjectPath)
-            this.$router.push({ query, name: page, params: { dashboard, environment: this.templateSelected.environment, slug: this.templateSelected.name}});
+            // TODO re-enable this when we're able to update the current namespace 
+            // https://github.com/onecommons/gitlab-oc/issues/867
+            // this.$router.push({ query, name: page, params: { dashboard, environment: this.templateSelected.environment, slug: this.templateSelected.name}});
+            window.location.href = this.$router.resolve({ query, name: page, params: { dashboard, environment: this.templateSelected.environment, slug: this.templateSelected.name}}).href
         },
 
         clearModalTemplate(e) {

--- a/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
+++ b/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
@@ -75,7 +75,7 @@ function normalizeEnvName(_name) {
 let Serializers
 Serializers = {
     DeploymentEnvironment(env) {
-        allowFields(env, 'connections', 'instances', 'external')
+        allowFields(env, 'connections', 'instances', 'external', 'repositories')
         fieldsToDictionary(env, 'connections', 'instances')
         if(env.instances.primary_provider) {
             env.connections.primary_provider = env.instances.primary_provider
@@ -563,6 +563,7 @@ const state = {
     accumulator: {},
     patches: {},
     committedNames: [],
+    commitMessage: null,
     env: {},
     isCommitting: false,
     useBaseState: false
@@ -598,6 +599,9 @@ const mutations = {
             state.preparedMutation = []
         }
         state.projectPath = projectPath
+    },
+    setCommitMessage(state, commitMessage) {
+        state.commitMessage = commitMessage
     },
     setEnvironmentScope(state, environmentScope) {
         state.environmentScope = environmentScope
@@ -642,6 +646,7 @@ const mutations = {
             state.path = undefined
             state.projectPath = undefined
             state.environmentScope = undefined
+            state.commitMessage = null
             state.preparedMutations = []
         }
     },
@@ -731,6 +736,10 @@ const actions = {
             fullPath: state.projectPath || rootState.project?.globalVars?.projectPath, 
             patch, 
             path: state.path || userDefaultPath()
+        }
+
+        if(state.commitMessage) {
+            variables.commitMessage = state.commitMessage
         }
 
         if(o?.dryRun) {

--- a/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
+++ b/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
@@ -446,7 +446,7 @@ export function deleteResourceTemplateInDependent({dependentName, dependentRequi
     }
 }
 
-export function createResourceTemplate({type, name, title, description, properties, dependencies, deploymentTemplateName, dependentName, dependentRequirement}) {
+export function createResourceTemplate({type, name, title, description, properties, dependencies, deploymentTemplateName, dependentName, dependentRequirement, imported}) {
     return function(accumulator) {
         const result = []
 
@@ -487,6 +487,7 @@ export function createResourceTemplate({type, name, title, description, properti
             name,
             title,
             description,
+            imported,
             __typename: "ResourceTemplate",
             properties: _properties,
             dependencies: _dependencies

--- a/packages/oc-pages/project_overview/store/modules/deployments.js
+++ b/packages/oc-pages/project_overview/store/modules/deployments.js
@@ -300,6 +300,7 @@ const getters = {
     getDeploymentDictionaries(state) {
         return state.deployments
     },
+    // TODO use getDeploymentsOrDrafts internally
     getDeployments(state) {
         if(!state.deployments) return []
         const result = []

--- a/packages/oc-pages/project_overview/store/modules/deployments.js
+++ b/packages/oc-pages/project_overview/store/modules/deployments.js
@@ -161,7 +161,7 @@ const getters = {
         }
         return result
     },
-    getDeploymentsOrDrafts() {
+    getDeploymentsOrDrafts(state, _a, _b, rootGetters) {
         if(!state.deployments) return []
         const result = []
         for(const dict of state.deployments) {
@@ -170,6 +170,13 @@ const getters = {
             Object.values(deployment).forEach(dep => {
                 result.push({...dep, _environment: dict._environment}) // _environment assigned on fetch in environments store
             })
+        }
+        for(const dashboard of rootGetters.getAdditionalDashboards) {
+            for(const dict of dashboard.deployments) {
+                const deployment = _.isObject(dict.Deployment)? dict.Deployment: dict.DeploymentTemplate
+                if(!deployment) continue
+                result.push(Object.values(deployment)[0])
+            }
         }
         return result
 

--- a/packages/oc-pages/project_overview/store/modules/deployments.js
+++ b/packages/oc-pages/project_overview/store/modules/deployments.js
@@ -3,9 +3,10 @@ import graphqlClient from '../../graphql';
 import {slugify, USER_HOME_PROJECT} from 'oc_vue_shared/util.mjs'
 import {environmentVariableDependencies, prefixEnvironmentVariables} from 'oc_vue_shared/lib/deployment-template'
 import {shareEnvironmentVariables} from 'oc_vue_shared/client_utils/environments'
+import Vue from 'vue'
 import _ from 'lodash'
 
-const state = {loaded: false, callbacks: [], deployments: {}, deploymentHooks: []};
+const state = {loaded: false, callbacks: [], deployments: {}, deploymentHooks: [], shareStates: {}};
 const mutations = {
     setDeployments(state, deployments) {
         state.deployments = deployments;
@@ -19,6 +20,10 @@ const mutations = {
 
     clearDeploymentHooks(state) {
         state.deploymentHooks = []
+    },
+
+    setShareState(state, {shareState, name}) {
+        Vue.set(state.shareStates, name, shareState)
     }
 };
 const actions = {
@@ -131,6 +136,151 @@ const actions = {
             if(result === false) { return false }
         }
         return true
+    },
+
+    unshareResourceFromEnvironment({commit, rootGetters}, {environmentName, deploymentName, resourceName}) {
+        commit(
+            'pushPreparedMutation',
+            (acc) => {
+                const environment = rootGetters.lookupEnvironment(environmentName)
+                const instances = environment.instances.filter(instance => instance.name != `__${environmentName}__${deploymentName}__${resourceName}`)
+                const patch = _.cloneDeep({...environment, instances})
+                return [{target: environmentName, patch, typename: 'DeploymentEnvironment'}];
+            },
+            {root: true}
+        )
+    },
+
+    unshareResourceFromDefaults({commit, rootGetters}, {environmentName, deploymentName, resourceName}) {
+        const name = `__${environmentName}__${deploymentName}__${resourceName}`
+        commit(
+            'pushPreparedMutation',
+            (acc) => {
+                const environment = rootGetters.getEnvironmentDefaults
+                // instances is initially an object for defaults
+                const instances = Object.values(environment.instances).filter(instance => instance.name != name)
+                const patch = _.cloneDeep({...environment, instances})
+                return [{target: 'defaults', patch, typename: 'DeploymentEnvironment'}];
+            },
+            {root: true}
+        )
+    },
+
+    async unshareResource({getters, commit, dispatch, rootGetters}, {environmentName, deploymentName, resourceName}) {
+        const currentShareState = getters.getResourceSharedState(environmentName, deploymentName, resourceName)
+        if(!currentShareState) return
+
+        commit('setShareState', {shareState: null, name: `__${environmentName}__${deploymentName}__${resourceName}` })
+
+        commit('useBaseState', {}, {root: true})
+        commit('setCommitMessage', `Unshare ${resourceName}`, {root: true})
+        commit('setUpdateObjectProjectPath', rootGetters.getHomeProjectPath, {root:true})
+        commit('setUpdateObjectPath', 'environments.json', {root: true})
+
+
+        if(currentShareState == 'environment') {
+            dispatch('unshareResourceFromEnvironment', {environmentName, deploymentName, resourceName})
+        } else if (currentShareState == 'dashboard') {
+            dispatch('unshareResourceFromDefaults', {environmentName, deploymentName, resourceName})
+        }
+
+        await dispatch('commitPreparedMutations')
+    },
+
+    shareResourceIntoEnvironment({commit, rootGetters}, {environmentName, deploymentName, resourceName}) {
+        // TODO not sure we want to couple with template_resources in here
+        const resource = rootGetters.getCardsStacked.find(card => card.name == resourceName)
+
+        const newObject = {
+            name: `__${environmentName}__${deploymentName}__${resourceName}`,
+            title: resource.title,
+            directives: ['select'],
+            imported: `${deploymentName}:${resource.name}`,
+            type: resource.type,
+            __typename: 'ResourceTemplate'
+        }
+
+        commit(
+            'pushPreparedMutation',
+            (acc) => {
+                // we can use acc here because updateResourceSharedState populated the state
+                //const patch = acc.DeploymentEnvironment[environmentName]
+                const patch = _.cloneDeep(rootGetters.lookupEnvironment(environmentName))
+                patch.instances.push(newObject)
+                return [{target: environmentName, patch, typename: 'DeploymentEnvironment'}];
+            },
+            {root: true}
+        )
+    },
+
+    shareResourcesIntoDefaults({commit, rootGetters}, {environmentName, deploymentName, resourceName}) {
+        const resource = rootGetters.getCardsStacked.find(card => card.name == resourceName)
+
+        const name = `__${environmentName}__${deploymentName}__${resourceName}`
+        const newObject = {
+            name,
+            title: resource.title,
+            directives: ['select'],
+            imported: `${deploymentName}:${resource.name}`,
+            type: resource.type,
+            __typename: 'ResourceTemplate'
+        }
+
+        commit(
+            'pushPreparedMutation',
+            (acc) => {
+                const patch = _.cloneDeep(rootGetters.getEnvironmentDefaults)
+                patch.instances[name] = newObject
+                return [{target: 'defaults', patch, typename: 'DeploymentEnvironment'}];
+            },
+            {root: true}
+        )
+    },
+
+    async updateResourceSharedState({getters, commit, dispatch, rootGetters}, {environmentName, deploymentName, resourceName, shareState}) {
+
+        const currentShareState = getters.getResourceSharedState(environmentName, deploymentName, resourceName)
+        if(!shareState || shareState == currentShareState) return
+
+        if(currentShareState) {
+            await dispatch('unshareResource', {environmentName, deploymentName, resourceName})
+        }
+
+        commit('setShareState', {shareState, name: `__${environmentName}__${deploymentName}__${resourceName}` })
+
+        commit('useBaseState', {}, {root: true})
+        commit('setCommitMessage', `Share ${resourceName} with ${shareState}`, {root: true})
+        commit('setUpdateObjectProjectPath', rootGetters.getHomeProjectPath, {root:true})
+        commit('setUpdateObjectPath', 'environments.json', {root: true})
+
+
+        // It's more difficult to clean this up, because we add the manifest per deployment
+        // removing it on removal of the shared resource could break the use of other shared resources
+        /*
+        commit(
+            'pushPreparedMutation',
+            (acc) => {
+                const patch = _.cloneDeep(rootGetters.lookupEnvironment(environmentName))
+                const external = patch.external || {}
+                const manifest = rootGetters.lookupDeployPath(deploymentName, environmentName)?.name
+                external[deploymentName] = {
+                    manifest,
+                    instance: "*"
+                }
+                patch.external = external
+                return [{target: environmentName, patch, typename: 'DeploymentEnvironment'}];
+            },
+            {root: true}
+        )
+        */
+
+        if(shareState == 'environment') {
+            dispatch('shareResourceIntoEnvironment', {environmentName, deploymentName, resourceName})
+        } else if (shareState == 'dashboard') {
+            dispatch('shareResourcesIntoDefaults', {environmentName, deploymentName, resourceName})
+        }
+
+        await dispatch('commitPreparedMutations')
     }
 };
 const getters = {
@@ -208,6 +358,25 @@ const getters = {
                 }
             })
             return result
+        }
+    },
+
+    getResourceSharedState(state, _a, _b, rootGetters) {
+        return function(environmentName, deploymentName, resourceName) {
+            const name = `__${environmentName}__${deploymentName}__${resourceName}`
+            if(state.shareStates.hasOwnProperty(name)) {
+                return state.shareStates[name]
+            }
+
+            let environmentDefaults
+            if(environmentDefaults = rootGetters.getEnvironmentDefaults) {
+                // instances is not an array here
+                try {
+                    if(environmentDefaults.instances[name]) return 'dashboard'
+                } catch(e) {}
+            }
+            if(rootGetters.lookupConnection(environmentName, name)) return 'environment'
+            return null
         }
     },
 

--- a/packages/oc-pages/project_overview/store/modules/environments.js
+++ b/packages/oc-pages/project_overview/store/modules/environments.js
@@ -444,6 +444,11 @@ const getters = {
         if(!type) return null
         return getters.getMatchingEnvironments(type).find(env => env.primary_provider && lookupCloudProviderAlias(env.primary_provider.type) == lookupCloudProviderAlias(type))?.name
     },
+    
+    getAdditionalDashboards(state) {
+        return state.additionalDashboards
+    },
+
     lookupConnection: (_, getters) => function(environmentName, connectedResource) {
         const environment = getters.lookupEnvironment(environmentName)
         //if(!environment) {throw new Error(`Environment ${environmentName} not found`)}

--- a/packages/oc-pages/project_overview/store/modules/environments.js
+++ b/packages/oc-pages/project_overview/store/modules/environments.js
@@ -23,6 +23,7 @@ const state = {
     variablesByEnvironment: {},
     saveEnvironmentHooks: [],
     additionalDashboards: [],
+    defaults: null,
     projectPath: null,
     ready: false,
     upstreamCommit: null, upstreamProject: null, upstreamId: null, incrementalDeploymentEnabled: false,
@@ -126,6 +127,10 @@ const mutations = {
 
     setAdditionalDashboards(state, additionalDashboards) {
         state.additionalDashboards = additionalDashboards
+    },
+
+    setDefaults(state, defaults) {
+        state.defaults = defaults
     }
 
 };
@@ -264,6 +269,7 @@ const actions = {
                 commit('setResourceTypeDictionary', {environment, dict: environment.ResourceType})
                 delete environment.ResourceType
             }
+            commit('setDefaults', result.defaults)
             commit('setDeploymentPaths', result.deploymentPaths)
         }
         catch(e){
@@ -536,7 +542,9 @@ const getters = {
     userCanEdit(_, getters) {
         // we can't read or set UNFURL_VAULT_DEFAULT_PASSWORD if we're not a maintainer
         return !!getters.lookupVariableByEnvironment('UNFURL_VAULT_DEFAULT_PASSWORD', '*')
-    }
+    },
+
+    getEnvironmentDefaults(state) { return state.defaults || null }
 };
 
 export default {

--- a/packages/oc-pages/project_overview/store/modules/environments.js
+++ b/packages/oc-pages/project_overview/store/modules/environments.js
@@ -1,3 +1,4 @@
+import axios from '~/lib/utils/axios_utils'
 import { __ } from "~/locale";
 import _ from 'lodash'
 import gql from 'graphql-tag'
@@ -10,7 +11,7 @@ import {prepareVariables, triggerPipeline} from 'oc_vue_shared/client_utils/pipe
 import {patchEnv, fetchEnvironmentVariables} from 'oc_vue_shared/client_utils/envvars'
 import {generateAccessToken} from 'oc_vue_shared/client_utils/user'
 import {generateProjectAccessToken} from 'oc_vue_shared/client_utils/projects'
-import {shareEnvironmentVariables} from 'oc_vue_shared/client_utils/environments'
+import {fetchEnvironments, connectionsToArray, shareEnvironmentVariables} from 'oc_vue_shared/client_utils/environments'
 import {tryResolveDirective} from 'oc_vue_shared/lib'
 import {prefixEnvironmentVariables, environmentVariableDependencies} from 'oc_vue_shared/lib/deployment-template'
 
@@ -21,32 +22,13 @@ const state = {
     resourceTypeDictionaries: {},
     variablesByEnvironment: {},
     saveEnvironmentHooks: [],
+    additionalDashboards: [],
     projectPath: null,
     ready: false,
     upstreamCommit: null, upstreamProject: null, upstreamId: null, incrementalDeploymentEnabled: false,
 };
 
-function connectionsToArray(environment) {
-    if(Array.isArray(environment)) return environment
-    if(environment.connections) {
-        for(const key in environment.connections) { 
-            if(isNaN(parseInt(key))) { //// not sure how much of this is still needed
-                delete environment.connections[key]
-            }
-        }
-        environment.connections = Object.values(environment.connections)
-    }
-    if(environment.instances) {
-        for(const key in environment.instances) { 
-            if(isNaN(parseInt(key))) { //// not sure how much of this is still needed
-                delete environment.instances[key]
-            }
-        }
-        environment.instances = Object.values(environment.instances)
-    }
 
-    return environment
-}
 
 function toProjectTokenEnvKey(projectId) {
     return `_project_token__${projectId}`
@@ -140,6 +122,10 @@ const mutations = {
 
     setVariablesByEnvironment(state, variablesByEnvironment) {
         state.variablesByEnvironment = variablesByEnvironment
+    },
+
+    setAdditionalDashboards(state, additionalDashboards) {
+        state.additionalDashboards = additionalDashboards
     }
 
 };
@@ -269,63 +255,16 @@ const actions = {
 
 
     async fetchProjectEnvironments({commit}, {fullPath, fetchPolicy}) {
-        const query = gql`
-        query getProjectEnvironments($fullPath: ID!) {
-            project(fullPath: $fullPath) {
-                environments {
-                    nodes {
-                        deploymentEnvironment @client {
-                            connections
-                            instances
-                            primary_provider
-                        }
-                        ResourceType @client
-                        deployments
-                        clientPayload
-                        name
-                        state
-                    }
-                }
-            }
-        }`
-        let environments
-        let deployments = []
+        let environments, deployments = []
         try {
-            const {data, errors} = await graphqlClient.clients.defaultClient.query({
-                query,
-                fetchPolicy,
-                errorPolicy: 'all',
-                variables: {fullPath}
-            })
-            if(errors) {throw new Error(errors)}
-
-            // cloning in the resolver can't be relied on unless we use a different fetchPolicy
-            // there's probably a better way of getting vuex to stop watching environments when we call this action
-            // alternatively we could check if it's cached
-            environments = cloneDeep(data.project.environments).nodes.map(environment => {
-                Object.assign(environment, environment.deploymentEnvironment)
-                // alternative to adding a graphql type?
-                environment.external = environment.clientPayload.DeploymentEnvironment.external || {}
-                const deploymentPaths = Object.values(environment.clientPayload.DeploymentPath || {})
+            const result = await fetchEnvironments({fullPath, fetchPolicy})
+            environments = result.environments
+            deployments = result.deployments
+            for(const environment of environments) {
                 commit('setResourceTypeDictionary', {environment, dict: environment.ResourceType})
-                commit('setDeploymentPaths', deploymentPaths)
                 delete environment.ResourceType
-                for(const deployment of environment.deployments) {
-                    if(!deployment._environment) deployment._environment = environment.name
-                    for(const dep of Object.values(deployment.Deployment || {})) {
-                        dep.__typename = 'Deployment'
-                    }
-                    deployments.push(deployment)
-                }
-                delete environment.deploymentEnvironment
-                delete environment.clientPayload
-                environment.__typename = 'DeploymentEnvironment' // just documenting this to avoid confusion with __typename Environment
-
-                connectionsToArray(environment)
-
-                return environment
-            })
-
+            }
+            commit('setDeploymentPaths', result.deploymentPaths)
         }
         catch(e){
             console.error('Could not fetch project environments', e)
@@ -374,12 +313,13 @@ const actions = {
         }
     },
     async ocFetchEnvironments({ commit, dispatch, rootGetters }, {fullPath, projectPath, fetchPolicy}) {
-        commit('setProjectPath', fullPath || projectPath)
+        const _projectPath = fullPath || projectPath || rootGetters.getHomeProjectPath
+        commit('setProjectPath', _projectPath)
         await Promise.all([
-            dispatch('fetchProjectEnvironments', {fullPath: fullPath || projectPath, fetchPolicy}),
-            dispatch('fetchEnvironmentVariables', {fullPath: fullPath || projectPath})
+            dispatch('fetchProjectEnvironments', {fullPath: _projectPath, fetchPolicy}),
+            dispatch('fetchEnvironmentVariables', {fullPath: _projectPath})
         ])
-        dispatch('generateVaultPasswordIfNeeded', {fullPath: fullPath || projectPath}).then(() => commit('setReady', true))
+        dispatch('generateVaultPasswordIfNeeded', {fullPath: _projectPath}).then(() => commit('setReady', true))
         dispatch('createAccessTokenIfNeeded')
     },
     async generateProjectTokenIfNeeded({getters, rootGetters}, {projectId}) {
@@ -427,6 +367,15 @@ const actions = {
             }]
         })
         await dispatch('commitPreparedMutations', {}, {root: true})
+    },
+
+    async loadAdditionalDashboards({rootGetters, commit}) {
+        const dashboards = (await axios.get(`/api/v4/dashboards?min_access_level=40`))?.data
+            ?.filter(dashboard => dashboard.path_with_namespace != rootGetters.getHomeProjectPath)
+            ?.map(dashboard => fetchEnvironments({fullPath: dashboard.path_with_namespace}))
+
+
+        commit('setAdditionalDashboards', await Promise.all(dashboards))
     }
 
 };
@@ -435,7 +384,9 @@ function envFilter(name){
 } 
 
 const getters = {
-    getEnvironments: state => Object.freeze(state.projectEnvironments),
+    getEnvironments: state => state.projectEnvironments
+        .concat(Object.values(state.additionalDashboards.map(db => db.environments)))
+        .flat(),
     lookupEnvironment: (_, getters) => function(name) {return getters.getEnvironments.find(envFilter(name))},
     getValidConnections: (state, _a, _b, rootGetters) => function(environmentName, requirement) {
         let constraintType
@@ -459,6 +410,8 @@ const getters = {
 
         return result
     },
+
+    // TODO merge these implementations
     getMatchingEnvironments: (_, getters) => function(type) {
         // uncomment to make local dev agnostic
         //if(!type) { return getters.getEnvironments }
@@ -469,6 +422,24 @@ const getters = {
         })
         return result
     },
+    getAdditionalMatchingEnvironments(state, getters) {
+        return function(type) {
+            const result = state.additionalDashboards.map(dashboard => {
+                const result = []
+                const {environments} = dashboard
+                for(const environment of environments) {
+                    if(lookupCloudProviderAlias(environment.primary_provider?.type) == lookupCloudProviderAlias(type)) {
+                        result.push(environment)
+                    }
+                }
+                return result
+            }).flat()
+
+            return result
+        }
+    },
+    //
+
     getDefaultEnvironmentName: (_, getters) => function(type) {
         if(!type) return null
         return getters.getMatchingEnvironments(type).find(env => env.primary_provider && lookupCloudProviderAlias(env.primary_provider.type) == lookupCloudProviderAlias(type))?.name

--- a/packages/oc-pages/project_overview/store/modules/template_resources.js
+++ b/packages/oc-pages/project_overview/store/modules/template_resources.js
@@ -678,7 +678,6 @@ const getters = {
         return function(cardName) {
             const card = state.resourceTemplates[cardName?.name || cardName]
             if(!card) return false
-            if(card.directives?.includes('select')) return true
 
             if(card.__typename == 'Resource') {
                 return getters.resourceCardIsHidden(card)

--- a/packages/oc-pages/project_overview/store/modules/template_resources.js
+++ b/packages/oc-pages/project_overview/store/modules/template_resources.js
@@ -486,11 +486,13 @@ const actions = {
                 )
             } 
 
+            /*
             commit('onSaveEnvironment', () => {
                 if(getters.cardIsValid(resource.name)) {
                     setManifestIfNeeded()
                 }
             })
+            */
 
             commit(
                 'pushPreparedMutation',

--- a/packages/oc-pages/vue_shared/client_utils/environments.js
+++ b/packages/oc-pages/vue_shared/client_utils/environments.js
@@ -169,6 +169,7 @@ export async function fetchEnvironments({fullPath, fetchPolicy}) {
     })
     if(errors) {throw new Error(errors)}
 
+    let defaults
     // cloning in the resolver can't be relied on unless we use a different fetchPolicy
     // there's probably a better way of getting vuex to stop watching environments when we call this action
     // alternatively we could check if it's cached
@@ -176,6 +177,7 @@ export async function fetchEnvironments({fullPath, fetchPolicy}) {
         Object.assign(environment, environment.deploymentEnvironment)
         // alternative to adding a graphql type?
         environment.external = environment.clientPayload.DeploymentEnvironment.external || {}
+        if(environment.clientPayload.defaults) defaults = environment.clientPayload.defaults
         deploymentPaths = deploymentPaths.concat(Object.values(environment.clientPayload.DeploymentPath || {}))
         //commit('setResourceTypeDictionary', {environment, dict: environment.ResourceType})
         //commit('setDeploymentPaths', deploymentPaths)
@@ -197,6 +199,6 @@ export async function fetchEnvironments({fullPath, fetchPolicy}) {
         return environment
     })
 
-    return {environments, deployments, deploymentPaths, fullPath}
+    return {environments, deployments, deploymentPaths, fullPath, defaults}
 
 }

--- a/packages/oc-pages/vue_shared/components/oc/deployment-resources.vue
+++ b/packages/oc-pages/vue_shared/components/oc/deployment-resources.vue
@@ -560,8 +560,8 @@ export default {
                             class="gl-mb-6"
                             @deleteNode="onDeleteNode"
                             >
-                            <template #controls>
-                                <slot name="controls"></slot>
+                            <template #controls="card">
+                                <slot name="controls" v-bind="card"></slot>
                             </template>
                             <template #content>
                                 <!--oc-inputs :card="card" :main-inputs="getCardProperties(card.name)" :component-key="2" /-->


### PR DESCRIPTION
! Depends on commits from https://github.com/onecommons/gitlab-oc/pull/1092/commits !

https://github.com/onecommons/gitlab-oc/issues/974
Current status
- [x] Share resources with environment
- [x] Share resources with dashboard
- [x] Unshare resources with environment
- [x] Unshare resources with dashboard
- [x] Switch sharing between environment and dashboard
- [x] Display cards in proper readonly mode
- [x] Temporary [1]: Don't allow remove on the environment page
- [ ] Followup [1]: The remove button should be available if the resource is shared with a single deployment
- [ ] Handle environment variables in cards
- [ ] Mark shared resource usage
- [ ] Warn users when teardown/unshare
- [ ] Allow removing the card in the deployment editor
- [ ] Link to issue page to share a resource publicly


had a github action failure for the last commit https://github.com/onecommons/unfurl-gui/actions/runs/3140193413/jobs/5101346257
```
Warning: Failed to download action 'https://api.github.com/repos/actions/setup-node/tarball/1f8c6b94b26d0feae1e387ca63ccbdc44d27b561'. Error: Response status code does not indicate success: 500 (Internal Server Error).
Warning: Back off 17.617 seconds before retry.
Warning: Failed to download action 'https://api.github.com/repos/actions/setup-node/tarball/1f8c6b94b26d0feae1e387ca63ccbdc44d27b561'. Error: Response status code does not indicate success: 500 (Internal Server Error).
Warning: Back off 15.924 seconds before retry.
Error: Response status code does not indicate success: 500 (Internal Server Error).
```
