### PR TITLE
Fix local command when the deployment ensemble hasn't been created yet

### DIFF
--- a/packages/oc-pages/dashboard/components/cells/deployment-controls.vue
+++ b/packages/oc-pages/dashboard/components/cells/deployment-controls.vue
@@ -84,8 +84,7 @@ export default {
                 result.push('view-artifacts')
             } 
 
-            // invocation doesn't currently work
-            if(!this.deploymentItem?.isDraft && !this.deploymentItem?.isUndeployed) result.push('local-deploy')
+            if(!this.deploymentItem?.isUndeployed) result.push('local-deploy')
             result.push('view-in-repository')
 
             // these checks are inadequate

--- a/packages/oc-pages/vue_shared/client_utils/unfurl-invocations.js
+++ b/packages/oc-pages/vue_shared/client_utils/unfurl-invocations.js
@@ -1,27 +1,22 @@
-export function cloneAlreadyDeployed({
-    protocol, username, token, server, projectPath, projectId, environmentName, deployPath
-}) {
-  const vars_url = unfurl_cloud_vars_url({protocol, token, server, projectId});
-  return (
-`unfurl clone '${protocol}//${username}:${token}@${server}/${projectPath}#:${deployPath}' --var UNFURL_CLOUD_VARS_URL '${vars_url}' --use-environment ${environmentName}`
-    )
-}
-
-export function unfurl_cloud_vars_url({
+function unfurl_cloud_vars_url({
   protocol, token, server, projectId
 }) {
   return `${protocol}//${server}/api/v4/projects/${projectId}/variables?per_page=1000&private_token=\${UNFURL_ACCESS_TOKEN:${token}}`
 }
 
-/*
- * unfurl clone https://<username>:<token>@<unfurl.server>/<project_path> --existing --overwrite --var UNFURL_CLOUD_VARS_URL 'https://<unfurl.server>/api/v4/projects/{project_id}/variables?filter=${ENVIRONMENT:*}&private_token=<token>' --mono --use-environment <environment> --use-deployment-blueprint <deployment> --skeleton dashboard <BLUEPRINT_PROJECT_URL> <DEPLOY_PATH>
- */
-
-export function cloneForDraft({
-    protocol, username, token, server, projectPath, projectId, environmentName, deploymentName, deployPath, blueprintUrl, blueprint
+export function cloneProject({
+    protocol, username, token, server, projectPath, projectId
 }) {
-    const vars_url = unfurl_cloud_vars_url({protocol, token, server, projectId});
+  const vars_url = unfurl_cloud_vars_url({protocol, token, server, projectId});
+  return (
+    `unfurl clone '${protocol}//${username}:${token}@${server}/${projectPath}' --var UNFURL_CLOUD_VARS_URL '${vars_url}'`
+  )
+}
+
+export function cloneBlueprint({
+  projectName, environmentName, deploymentName, deployPath, blueprintUrl
+}) {
     return (
-`unfurl clone '${protocol}//${username}:${token}@${server}/${projectPath}' --existing --overwrite --var UNFURL_CLOUD_VARS_URL '${vars_url}' --mono --use-environment ${environmentName} --use-deployment-blueprint ${blueprint} --skeleton dashboard ${blueprintUrl} ${deployPath}`
+      `cd ${projectName}; unfurl clone --existing --overwrite --mono --use-environment ${environmentName} --use-deployment-blueprint ${deploymentName} --skeleton dashboard ${blueprintUrl} ${deployPath}`
     )
 }

--- a/packages/oc-pages/vue_shared/components/oc/local-deploy.vue
+++ b/packages/oc-pages/vue_shared/components/oc/local-deploy.vue
@@ -66,6 +66,7 @@ export default {
         <p >
             Clone this Unfurl project if you haven't already:
             <code-clipboard class="mt-1">{{localCloneInvocation}}</code-clipboard>
+            (Or if you have, run "git pull" to get latest.)
         </p>
         <p v-if="!deploymentExists"> 
             Create the deployment from the blueprint.

--- a/packages/oc-pages/vue_shared/components/oc/local-deploy.vue
+++ b/packages/oc-pages/vue_shared/components/oc/local-deploy.vue
@@ -1,7 +1,7 @@
 <script>
 import CodeClipboard from './code-clipboard.vue'
 import {mapGetters} from 'vuex'
-import {cloneAlreadyDeployed, cloneForDraft} from 'oc_vue_shared/client_utils/unfurl-invocations'
+import {cloneProject, cloneBlueprint} from 'oc_vue_shared/client_utils/unfurl-invocations'
 
 
 export default {
@@ -20,7 +20,7 @@ export default {
             'lookupVariableByEnvironment',
             'lookupDeployPath'
         ]),
-        localCloneInvocation() {
+        _localCloneOptions() {
             const protocol = window.location.protocol
             const username = this.getUsername
             const token = this.lookupVariableByEnvironment('UNFURL_ACCESS_TOKEN', '*')
@@ -30,28 +30,28 @@ export default {
             }
             const projectPath = this.getHomeProjectPath
             const projectId = window.gon.projectId // TODO fix gon.projectId hack
+            const projectName = this.getHomeProjectPath.split('/').pop()            
             const deploymentName = this.deployment.name
             const environmentName = this.environment.name
             const deployPath = this.lookupDeployPath(deploymentName, environmentName)?.name
             const blueprint = this.deployment.blueprint
             const blueprintUrl = `${protocol}//${username}:${token}@${server}/${this.deployment.projectPath}`
-
-            const options = {protocol, username, token, server, projectPath, projectId, environmentName, deploymentName, deployPath, blueprint, blueprintUrl}
-            if(this.deployment.__typename == 'DeploymentTemplate') {
-                return cloneForDraft(options)
-            } else {
-                return cloneAlreadyDeployed(options)
-            }
+            return { protocol, username, token, server, projectName, projectPath, projectId, environmentName, deploymentName, deployPath, blueprint, blueprintUrl }
+        },
+        localCreateDeploymentInvocation() {
+            return cloneBlueprint(this._localCloneOptions())
+        },
+        localCloneInvocation() {
+            return cloneProject(this._localCloneOptions())
         },
         localDeployInvocation() {
             const projectName = this.getHomeProjectPath.split('/').pop()
             const deploymentName = this.deployment.name
             const environmentName = this.environment.name
             const deployPath = this.lookupDeployPath(deploymentName, environmentName)?.name
-            const protocol = window.location.protocol
-            const token = this.lookupVariableByEnvironment('UNFURL_ACCESS_TOKEN', '*')
             return `cd ${projectName}; unfurl deploy ${deployPath} --use-environment ${environmentName} --commit`
-        }
+        },
+        deploymentExists() { return deployment.__typename != 'DeploymentTemplate' }
     }
 }
 
@@ -60,15 +60,19 @@ export default {
     <div>
         <p>Run these shell commands to deploy this on your local machine:</p>
         <p>
-            Install Unfurl:
+            Install Unfurl if needed:
             <code-clipboard class="mt-1">python -m pip install -U unfurl</code-clipboard>
         </p>
-        <p>
-            Clone from Unfurl.cloud:
+        <p >
+            Clone this Unfurl project if you haven't already:
             <code-clipboard class="mt-1">{{localCloneInvocation}}</code-clipboard>
         </p>
+        <p v-if="!deploymentExists"> 
+            Create the deployment from the blueprint.
+            <code-clipboard class="mt-1">{{localCreateDeploymentInvocation}}</code-clipboard>
+        </p>
         <p>
-            Deploy your application:
+            Deploy the blueprint:
             <code-clipboard class="mt-1">{{localDeployInvocation}}</code-clipboard>
         </p>
         <p>Learn more at <a href="https://github.com/onecommons/unfurl" target="_blank">https://github.com/onecommons/unfurl</a>.</p>

--- a/packages/oc-pages/vue_shared/components/oc/local-deploy.vue
+++ b/packages/oc-pages/vue_shared/components/oc/local-deploy.vue
@@ -23,7 +23,7 @@ export default {
         _localCloneOptions() {
             const protocol = window.location.protocol
             const username = this.getUsername
-            const token = this.lookupVariableByEnvironment('UNFURL_ACCESS_TOKEN', '*')
+            const token = this.lookupVariableByEnvironment('UNFURL_PROJECT_TOKEN', '*')
             let server  = window.location.hostname
             if(window.location.port) {
                 server = server + ':' + window.location.port
@@ -39,19 +39,19 @@ export default {
             return { protocol, username, token, server, projectName, projectPath, projectId, environmentName, deploymentName, deployPath, blueprint, blueprintUrl }
         },
         localCreateDeploymentInvocation() {
-            return cloneBlueprint(this._localCloneOptions())
+            return cloneBlueprint(this._localCloneOptions)
         },
         localCloneInvocation() {
-            return cloneProject(this._localCloneOptions())
+            return cloneProject(this._localCloneOptions)
         },
         localDeployInvocation() {
             const projectName = this.getHomeProjectPath.split('/').pop()
             const deploymentName = this.deployment.name
             const environmentName = this.environment.name
             const deployPath = this.lookupDeployPath(deploymentName, environmentName)?.name
-            return `cd ${projectName}; unfurl deploy ${deployPath} --use-environment ${environmentName} --commit`
+            return `unfurl deploy --commit ${deployPath} --use-environment ${environmentName}`
         },
-        deploymentExists() { return deployment.__typename != 'DeploymentTemplate' }
+        deploymentExists() { return this.deployment.__typename != 'DeploymentTemplate' }
     }
 }
 


### PR DESCRIPTION
cloneAsDraft() was broken... also with this fix we can now display these commands on the deploy page without having to run the pipeline (assuming deploy.json is committed).