### PR TITLE
Disregard ensemble.json ResourceType dictionary when editing deployments (14.9)

### DIFF
--- a/packages/oc-pages/project_overview/store/modules/template_resources.js
+++ b/packages/oc-pages/project_overview/store/modules/template_resources.js
@@ -182,7 +182,7 @@ const actions = {
                 try {dt = Object.values(dict.DeploymentTemplate)[0]} catch(e) {}
                 if(dt?.slug != templateSlug && dt?.name != templateSlug) continue
 
-                dispatch('useProjectState', {root: _.cloneDeep(dict), shouldMerge: true, projectPath})
+                dispatch('useProjectState', {root: _.cloneDeep({...dict, ResourceType: undefined}), shouldMerge: true, projectPath})
                 _syncState = false // override sync state if we just loaded this
                 /*
                 deploymentTemplate = _.cloneDeep(dt)


### PR DESCRIPTION
https://github.com/onecommons/gitlab-oc/issues/1275