### PR TITLE
Switch over connected repos to deploy token, add BLUEPRINT_TOKEN_VAR

### DIFF
--- a/packages/oc-pages/dashboard/pages/environment.vue
+++ b/packages/oc-pages/dashboard/pages/environment.vue
@@ -269,14 +269,15 @@ export default {
                 </div>
             </template>
         </oc-properties-list>
-        <div v-if="userCanEdit" class="mt-3">
+        <!-- this isn't hooked up yet, add back when ready -->
+        <!--div v-if="userCanEdit" class="mt-3">
             <gl-button variant="confirm">
                 <div>
                     <gl-icon name="plus"/>
                     {{__('Add a Provider')}}
                 </div>
             </gl-button>
-        </div>
+        </div-->
 
         <gl-tabs v-model="currentTab" class="mt-4">
             <oc-tab title="Provider" v-if="hasProviderTab"></oc-tab>

--- a/packages/oc-pages/project_overview/components/shared/oc_inputs/GithubMirroredRepoImageSource.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_inputs/GithubMirroredRepoImageSource.vue
@@ -8,6 +8,7 @@ import {fetchContainerRepositories, fetchRepositoryBranches, fetchProjectInfo} f
 import {triggerPipeline} from 'oc_vue_shared/client_utils/pipelines'
 import {GithubImportHandler, importStatus, oauthStatus} from 'oc_vue_shared/client_utils/github-import'
 import {generateIssueLinkSync} from 'oc_vue_shared/client_utils/issues'
+import {toDepTokenEnvKey} from 'oc_vue_shared/client_utils/envvars'
 import {mapMutations, mapActions, mapGetters, mapState} from 'vuex'
 import GithubAuth from 'oc_vue_shared/components/oc/github-auth.vue'
 import ImportButton from 'oc_vue_shared/components/oc/import-button.vue'
@@ -158,9 +159,8 @@ export default {
             this.projectInfo = await fetchProjectInfo(projectId)
         },
         async setupRegistryCredentials(projectId) {
-            const {key} = await this.generateProjectTokenIfNeeded({projectId})
             this.username = 'DashboardProjectAccessToken'
-            this.password = {get_env: key}
+            this.password = {get_env: toDepTokenEnvKey(projectId)}
             this.updateValue('username')
             this.updateValue('password')
         },

--- a/packages/oc-pages/project_overview/components/shared/oc_inputs/LocalImageRepoSource.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_inputs/LocalImageRepoSource.vue
@@ -3,6 +3,7 @@ import gql from 'graphql-tag'
 import graphqlClient from 'oc/graphql-shim'
 import {Autocomplete as ElAutocomplete, Input as ElInput, Card as ElCard} from 'element-ui'
 import {fetchProjects, fetchRegistryRepositories, fetchContainerRepositories, fetchProjectInfo} from 'oc_vue_shared/client_utils/projects'
+import {toDepTokenEnvKey} from 'oc_vue_shared/client_utils/envvars'
 import {mapGetters, mapActions, mapMutations} from 'vuex'
 import DeploymentScheduler from '../../../../vue_shared/components/oc/deployment-scheduler.vue'
 
@@ -18,12 +19,9 @@ export default {
         card: Object
     },
     data() {
-
-        const accessToken = this.$store.getters.lookupEnvironmentVariable('UNFURL_ACCESS_TOKEN')
         const data = {
             containerRepositories: null,
             userProjectSuggestionsPromise: fetchProjects({minAccessLevel: 0}),
-            accessToken,
             containerRepositoriesPromise: null,
             username: null,
             password: null,
@@ -80,9 +78,8 @@ export default {
         async setupRegistryCredentials() {
             if(!this.project_id) return
             const projectId = (await fetchProjectInfo(encodeURIComponent(this.project_id))).id
-            const {key} = await this.generateProjectTokenIfNeeded({projectId})
             this.username = 'DashboardProjectAccessToken'
-            this.password = {get_env: key}
+            this.password = {get_env: toDepTokenEnvKey(projectId)}
             this.updateValue('username')
             this.updateValue('password')
         },

--- a/packages/oc-pages/project_overview/components/shared/oc_inputs/UnfurlCloudMirroredRepoImageSource.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_inputs/UnfurlCloudMirroredRepoImageSource.vue
@@ -1,6 +1,7 @@
 <script>
 import axios from '~/lib/utils/axios_utils'
 import {mapActions, mapMutations, mapGetters} from 'vuex'
+import {toDepTokenEnvKey} from 'oc_vue_shared/client_utils/envvars'
 import {fetchProjects, fetchRepositoryBranches, fetchProjectInfo} from 'oc_vue_shared/client_utils/projects'
 import DeploymentScheduler from '../../../../vue_shared/components/oc/deployment-scheduler.vue'
 
@@ -19,10 +20,8 @@ export default {
         DeploymentScheduler
     },
     data() {
-        const accessToken = this.$store.getters.lookupEnvironmentVariable('UNFURL_ACCESS_TOKEN')
         const data = {
             userProjectSuggestionsPromise: fetchProjects({minAccessLevel: 10}),
-            accessToken,
             repositoryBranchesPromise: null,
             project_id: null,
             branch: null,
@@ -65,9 +64,8 @@ export default {
             )
         },
         async setupRegistryCredentials(gitlabProjectId) {
-            //const {key} = await this.generateProjectTokenIfNeeded({projectId: gitlabProjectId})
             this.username = 'DashboardProjectAccessToken'
-            this.password = {get_env: `_dep_${gitlabProjectId}`}
+            this.password = {get_env: toDepTokenEnvKey(gitlabProjectId)}
             this.updateValue('username')
             this.updateValue('password')
         },

--- a/packages/oc-pages/project_overview/components/template/template_buttons.vue
+++ b/packages/oc-pages/project_overview/components/template/template_buttons.vue
@@ -142,9 +142,8 @@ export default {
                     {{deployTooltip}}
                 </div>
             </template>
-            <div class="d-flex flex-column position-relative">
+            <div v-if="deployStatus != 'hidden' && !editingTorndown" class="d-flex flex-column position-relative">
                 <gl-button
-                    v-show="deployStatus != 'hidden' && !editingTorndown"
                     :aria-label="__('Deploy')"
                     data-testid="deploy-button"
                     :title="!deployTooltip? 'Deploy': null"
@@ -161,7 +160,6 @@ export default {
                         <span style="line-height: 1;">Deployment is incomplete</span><i style="font-size: 1.25em;" class="el-icon-info ml-1"/>
                     </div>
                 </error-small>
-                <!--gl-button v-else type="button" class="deploy-action" loading>{{ __('Deploying...') }}</gl-button-->
         </div>
     </el-tooltip>
     </div>

--- a/packages/oc-pages/project_overview/store/modules/environments.js
+++ b/packages/oc-pages/project_overview/store/modules/environments.js
@@ -5,10 +5,8 @@ import {cloneDeep} from 'lodash'
 import {lookupCloudProviderAlias } from 'oc_vue_shared/util.mjs'
 import {isDiscoverable} from 'oc_vue_shared/client_utils/resource_types'
 import createFlash, { FLASH_TYPES } from 'oc_vue_shared/client_utils/oc-flash';
-import {prepareVariables, triggerPipeline, triggerAtomicDeployment} from 'oc_vue_shared/client_utils/pipelines'
-import {patchEnv, fetchEnvironmentVariables} from 'oc_vue_shared/client_utils/envvars'
-import {generateAccessToken} from 'oc_vue_shared/client_utils/user'
-import {generateGroupAccessToken} from 'oc_vue_shared/client_utils/group'
+import {prepareVariables, triggerAtomicDeployment} from 'oc_vue_shared/client_utils/pipelines'
+import {toDepTokenEnvKey, patchEnv, fetchEnvironmentVariables} from 'oc_vue_shared/client_utils/envvars'
 import {fetchProjectInfo, generateProjectAccessToken} from 'oc_vue_shared/client_utils/projects'
 import {fetchEnvironments, connectionsToArray, shareEnvironmentVariables} from 'oc_vue_shared/client_utils/environments'
 import {tryResolveDirective} from 'oc_vue_shared/lib'
@@ -36,10 +34,6 @@ const state = () => ({
 });
 
 
-
-function toProjectTokenEnvKey(projectId) {
-    return `_project_token__${projectId}`
-}
 
 const mutations = {
     setProjectPath(state, projectPath) {
@@ -187,18 +181,20 @@ const actions = {
         if(upstreamProjectPath) {
             commit('addRepositoryDependencies', [upstreamProjectPath])
         }
-            
-        const projectIds = await Promise.all(
-            state.repositoryDependencies.map(dep => fetchProjectInfo(encodeURIComponent(dep)).then(project => project.id))
+
+        const projects = await Promise.all(
+            state.repositoryDependencies.map(dep => fetchProjectInfo(encodeURIComponent(dep)))
         )
 
         const dashboardProjectId = (await fetchProjectInfo(encodeURIComponent(rootGetters.getHomeProjectPath))).id
 
-        let writableBlueprintProjectUrl
+        let writableBlueprintProjectUrl, blueprintToken
         const dependencies = state.repositoryDependencies
             .reduce(
                 (acc, v, i) => {
-                    const variableName = `_dep_${projectIds[i]}`
+                    const project = projects[i]
+                    if(project.visibility == 'public') return acc
+                    const variableName = toDepTokenEnvKey(project.id)
 
                     // TODO move this side effect out of a reduce
                     if(parameters.projectUrl.includes(`${v}.git`)) {
@@ -206,6 +202,7 @@ const actions = {
                         writableBlueprintProjectUrl.username = `UNFURL_DEPLOY_TOKEN_${dashboardProjectId}`
                         writableBlueprintProjectUrl.password = '$' + variableName
                         writableBlueprintProjectUrl = writableBlueprintProjectUrl.toString()
+                        blueprintToken = variableName
                     }
 
                     if(!getters.lookupVariableByEnvironment(variableName, '*')) {
@@ -217,12 +214,10 @@ const actions = {
                 {}
             )
 
-        // will be verifying some cloning cases
-        console.log({projectIds, dependencies, parameters})
-
         const deployVariables = await prepareVariables({
             ...parameters,
             writableBlueprintProjectUrl,
+            blueprintToken,
             upstreamCommit: state.upstreamCommit?.id || state.upstreamCommit,
             upstreamBranch: state.upstreamBranch,
             upstreamProject: state.upstreamProject,
@@ -482,7 +477,7 @@ const actions = {
         dispatch('createAccessTokenIfNeeded', {fullPath: _projectPath})
     },
     async generateProjectTokenIfNeeded({getters, rootGetters}, {projectId}) {
-        const key = toProjectTokenEnvKey(projectId)
+        const key = toDepTokenEnvKey(projectId)
         let token
         if(!(token = getters.lookupProjectToken(projectId))) {
             const token = await generateProjectAccessToken(projectId)
@@ -674,7 +669,7 @@ const getters = {
     },
     lookupProjectToken(state, getters) {
         return function(projectId) {
-            const key = toProjectTokenEnvKey(projectId)
+            const key = toDepTokenEnvKey(projectId)
             return getters.lookupVariableByEnvironment(key, '*')
         }
     },

--- a/packages/oc-pages/vue_shared/client_utils/envvars.js
+++ b/packages/oc-pages/vue_shared/client_utils/envvars.js
@@ -2,6 +2,9 @@ import axios from '~/lib/utils/axios_utils'
 
 import {USER_HOME_PROJECT} from '../util.mjs'
 
+export function toDepTokenEnvKey(projectId) {
+    return `_dep_${projectId}`
+}
 
 export async function patchEnv(env, environmentScope, fullPath) {
     if(!fullPath) {

--- a/packages/oc-pages/vue_shared/client_utils/pipelines.js
+++ b/packages/oc-pages/vue_shared/client_utils/pipelines.js
@@ -54,7 +54,7 @@ export async function triggerAtomicDeployment(projectPath, {ref='main', schedule
 
 // this doens't need to be async if generateAccessToken is done upon first sign-in with the vault token, but I think it's a good contract to enforce
 // it's possible we'll want to make async calls here in the future
-export async function prepareVariables({workflow, projectUrl, environmentName, deployPath, deploymentName, deploymentBlueprint, writableBlueprintProjectUrl, mockDeploy, upstreamCommit, upstreamBranch, upstreamProject, upstreamProjectPath, projectDnsZone}) {
+export async function prepareVariables({workflow, projectUrl, environmentName, deployPath, deploymentName, deploymentBlueprint, writableBlueprintProjectUrl, blueprintToken, mockDeploy, upstreamCommit, upstreamBranch, upstreamProject, upstreamProjectPath, projectDnsZone}) {
 
     const UNFURL_TRACE = !!Object.keys(sessionStorage).find(key => key == 'unfurl-trace') // TODO propagate this from misc store
     const DEPLOY_IMAGE = sessionStorage['deploy-image']
@@ -84,6 +84,7 @@ export async function prepareVariables({workflow, projectUrl, environmentName, d
     }).concat(
         toGlVariablesAttributes({
             WRITABLE_BLUEPRINT_PROJECT_URL: writableBlueprintProjectUrl ?? null,
+            BLUEPRINT_TOKEN_VAR: blueprintToken ?? null,
         }, 'env_var')
     )
 }


### PR DESCRIPTION
`BLUEPRINT_TOKEN_VAR` contains only the envvar containing the blueprint deploy token (`$_dep_<project-id>`) as opposed to the full URL like `WRITABLE_BLUEPRINT_PROJECT_URL`