### PR TITLE
Use an iframe to load cross origin unfurl-server-url

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -25,6 +25,8 @@ const DEPLOY_IMAGE = Cypress.env('DEPLOY_IMAGE')
 const DEPLOY_TAG = Cypress.env('DEPLOY_TAG') // no longer in use
 const INTEGRATION_TEST_ARGS = Cypress.env('INTEGRATION_TEST_ARGS') 
 
+const UNFURL_SERVER_URL = Cypress.env('UNFURL_SERVER_URL')
+
 const UNFURL_VALIDATION_MODE = Cypress.env('UNFURL_VALIDATION_MODE') || Cypress.env('VALIDATION_MODE')
 
 Cypress.Cookies.defaults({
@@ -69,6 +71,9 @@ beforeEach(() => {
     }
     if(UNFURL_VALIDATION_MODE) {
       win.sessionStorage['unfurl-validation-mode'] = UNFURL_VALIDATION_MODE
+    }
+    if(UNFURL_SERVER_URL) {
+      win.sessionStorage['unfurl-server-url'] = UNFURL_SERVER_URL
     }
     win.sessionStorage['unfurl-trace'] = 't'
   })

--- a/packages/oc-pages/dashboard/dashboard.vue
+++ b/packages/oc-pages/dashboard/dashboard.vue
@@ -6,11 +6,12 @@ import {deleteEnvironmentByName} from 'oc_vue_shared/client_utils/environments'
 import {notFoundError} from 'oc_vue_shared/client_utils/error'
 import {GlLoadingIcon} from '@gitlab/ui'
 import * as routes from './router/constants'
+import ExperimentalSettingIndicator from 'oc_vue_shared/components/oc/experimental-settings-indicator.vue'
 const USER_TOURED_EXPLORE_PAGE = 'USER_TOURED_EXPLORE_PAGE'
 export default {
     name: 'Dashboard',
     data() {return {isLoaded: false, doNotRender: false}},
-    components: {GlLoadingIcon},
+    components: {GlLoadingIcon, ExperimentalSettingIndicator},
     methods: {
         ...mapActions([
             'loadDashboard',
@@ -80,6 +81,7 @@ export default {
 </script>
 <template>
     <div>
+        <experimental-setting-indicator />
         <gl-loading-icon v-if="!isLoaded" label="Loading" size="lg" style="margin-top: 5em;" />
         <router-view v-else-if="!doNotRender"/>
     </div>

--- a/packages/oc-pages/project_overview/components/main.vue
+++ b/packages/oc-pages/project_overview/components/main.vue
@@ -3,6 +3,7 @@ import { FLASH_TYPES } from 'oc_vue_shared/client_utils/oc-flash';
 import { __ } from '~/locale';
 import gql from 'graphql-tag'
 import graphqlClient from '../graphql';
+import ExperimentalSettingIndicator from 'oc_vue_shared/components/oc/experimental-settings-indicator.vue'
 
 
 const ERROR_CONTEXT = {
@@ -12,6 +13,9 @@ const ERROR_CONTEXT = {
 export default {
     name: 'MainComponent',
     // TODO move this into page level components
+    components: {
+        ExperimentalSettingIndicator
+    },
     async beforeCreate() {
         let errorContext
 
@@ -93,6 +97,7 @@ export default {
 <template>
     <!-- <gl-loading-icon v-if="!fetchingComplete" label="Loading" size="lg" style="margin-top: 5em;" /> -->
     <div id="OcAppDeployments">
+        <experimental-setting-indicator />
         <router-view />
     </div>
 </template>

--- a/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
+++ b/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
@@ -849,7 +849,6 @@ const actions = {
         const branch = state.branch || project.default_branch
 
         const post = unfurlServerUpdate({
-            baseUrl: rootGetters.unfurlServicesUrl,
             method,
             projectPath,
             branch,

--- a/packages/oc-pages/project_overview/store/modules/deployments.js
+++ b/packages/oc-pages/project_overview/store/modules/deployments.js
@@ -339,43 +339,6 @@ const actions = {
         await dispatch('commitPreparedMutations')
     },
 
-    // TODO move fetch logic into client_utils
-    async fetchDeployment({state, commit, rootGetters}, {deployPath, fullPath}) {
-        const username = rootGetters.getUsername
-        const password = await fetchUserAccessToken()
-
-        const [latestCommit, branch] = await fetchLastCommit(encodeURIComponent(fullPath))
-
-        let deploymentUrl = `${rootGetters.unfurlServicesUrl}/export?format=deployment`
-        deploymentUrl += `&username=${username}`
-        deploymentUrl += `&password=${password}`
-        deploymentUrl += `&deployment_path=${encodeURIComponent(deployPath.name)}`
-        deploymentUrl += `&environment=${deployPath.environment}`
-        deploymentUrl += `&auth_project=${encodeURIComponent(fullPath)}`
-        deploymentUrl += `&branch=${branch}`
-        deploymentUrl += `&latest_commit=${latestCommit}`
-
-        try {
-            const {data} = await axios.get(deploymentUrl)
-
-            data._environment = deployPath.environment
-
-            const deployments = [...state.deployments]
-
-            let index = deployments.findIndex(dep => Object.values(dep.Deployment)[0].name == Object.values(data.Deployment)[0].name && dep._environment == deployPath.environment)
-
-            if(index != -1) {
-                deployments[index] = data
-            } else {
-                deployments.push(data)
-            }
-
-            commit('setDeployments',  deployments)
-        }catch(e) {
-            console.error(e)
-        }
-
-    }
 };
 const getters = {
     getDeploymentDictionary(state) {

--- a/packages/oc-pages/project_overview/store/modules/environments.js
+++ b/packages/oc-pages/project_overview/store/modules/environments.js
@@ -346,11 +346,10 @@ const actions = {
     },
 
 
-    async fetchProjectEnvironments({commit, dispatch, rootGetters}, {fullPath}) {
+    async fetchProjectEnvironments({commit, dispatch}, {fullPath}) {
         let environments = []
         try {
             const projectId = (await fetchProjectInfo(encodeURIComponent(fullPath))).id
-            const unfurlServicesUrl = rootGetters.unfurlServicesUrl
 
             // TODO don't hardcode main
             const branch = 'main'
@@ -359,7 +358,6 @@ const actions = {
                 fullPath,
                 branch,
                 projectId,
-                unfurlServicesUrl,
                 includeDeployments: true
             })
 
@@ -523,7 +521,7 @@ const actions = {
         // include developer access for deploy requests, etc.
         const dashboards = (await axios.get(`/api/v4/dashboards?min_access_level=30`))?.data
             ?.filter(dashboard => dashboard.path_with_namespace != rootGetters.getHomeProjectPath)
-            ?.map(dashboard => fetchEnvironments({fullPath: dashboard.path_with_namespace, projectId: dashboard.project_id, unfurlServicesUrl: rootGetters.unfurlServicesUrl}))
+            ?.map(dashboard => fetchEnvironments({fullPath: dashboard.path_with_namespace, projectId: dashboard.project_id}))
 
         commit('setAdditionalDashboards', await Promise.all(dashboards))
     }

--- a/packages/oc-pages/project_overview/store/modules/misc.js
+++ b/packages/oc-pages/project_overview/store/modules/misc.js
@@ -93,7 +93,7 @@ const getters = {
 
 const actions = {
     handleResize({commit, state}) {
-        window.addEventListener('resize', _.debounce(
+        window.addEventListener('resize', _.throttle(
             function(e) {
                 const _isMobileLayout = isMobileLayout()
                 if(_isMobileLayout != state.isMobileLayout) {

--- a/packages/oc-pages/project_overview/store/modules/misc.js
+++ b/packages/oc-pages/project_overview/store/modules/misc.js
@@ -62,9 +62,6 @@ const getters = {
     getUser(state) {
         return state.user
     },
-    unfurlServicesUrl() {
-        return unfurlServerUrlOverride() || '/services/unfurl-server'
-    },
     getFullname() {return window.gon.current_user_fullname},
     isMobileLayout() {return state.isMobileLayout},
     pipelinesPath(_, getters) { return `/${getters.getHomeProjectPath}/-/pipelines` },

--- a/packages/oc-pages/project_overview/store/modules/project_application_blueprint.js
+++ b/packages/oc-pages/project_overview/store/modules/project_application_blueprint.js
@@ -36,12 +36,11 @@ const mutations = {
 
 }
 const actions = {
-    async fetchProject({commit, dispatch, rootGetters}, params) {
+    async fetchProject({commit, dispatch}, params) {
         const {projectPath, projectGlobal} = params
         commit('loaded', false)
 
         const root = await unfurlServerExport({
-            baseUrl: rootGetters.unfurlServicesUrl,
             format: 'blueprint',
             projectPath,
             //TODO pass branch

--- a/packages/oc-pages/vue_shared/client_utils/environments.js
+++ b/packages/oc-pages/vue_shared/client_utils/environments.js
@@ -91,8 +91,7 @@ export async function deleteEnvironment(projectPath, projectId, environmentName,
 }
 
 // NOTE try to keep this in sync with commitPreparedMutations
-// NOTE can be invoked from cluster creation views - unfurlServicesUrl fallback to /services/unfurl-server 
-export async function initUnfurlEnvironment(projectPath, environment, variables={}, unfurlServicesUrl='/services/unfurl-server') {
+export async function initUnfurlEnvironment(projectPath, environment, variables={}) {
     const branch = 'main' // TODO don't hardcode main
 
     const patch = [{
@@ -104,7 +103,6 @@ export async function initUnfurlEnvironment(projectPath, environment, variables=
     const method = variables.deployment_path? 'create_provider': 'update_environment'
 
     await unfurlServerUpdate({
-        baseUrl: unfurlServicesUrl,
         commitMessage: `Create environment '${environment.name}' in ${projectPath}`,
         projectPath,
         method: method,
@@ -149,13 +147,12 @@ export function connectionsToArray(environment) {
     return environment
 }
 
-export async function fetchEnvironments({fullPath, unfurlServicesUrl, includeDeployments, branch}) {
+export async function fetchEnvironments({fullPath, includeDeployments, branch}) {
 
     // TODO get the branch passed into fetch environments
     // TODO use ?include_deployments=true
 
     const data = await unfurlServerExport({
-        baseUrl: unfurlServicesUrl,
         format: 'environments',
         projectPath: fullPath,
         includeDeployments,

--- a/packages/oc-pages/vue_shared/client_utils/unfurl-server.js
+++ b/packages/oc-pages/vue_shared/client_utils/unfurl-server.js
@@ -1,22 +1,103 @@
 import axios from '~/lib/utils/axios_utils'
 import { fetchUserAccessToken } from './user';
 import { fetchLastCommit, setLastCommit } from "./projects";
-import {shouldEncodePasswordsInExportUrl} from '../storage-keys';
+import {XHR_JAIL_URL, DEFAULT_UNFURL_SERVER_URL, shouldEncodePasswordsInExportUrl, unfurlServerUrlOverride} from '../storage-keys';
 
-function createConfig({includePasswordInQuery, username, password}) {
-    const config = {}
+function createHeaders({includePasswordInQuery, username, password}) {
     const headers = {}
 
     if(!includePasswordInQuery && username && password) {
         headers['x-git-credentials'] = btoa(username + ':' + password)
     }
 
-    config.headers = headers
-
-    return config
+    return headers
 }
 
-export async function unfurlServerExport({baseUrl, format, branch, projectPath, includeDeployments}) {
+function genUid() {
+    return Math.random().toString(36).slice(-6)
+}
+
+class UnfurlServerIFrame {
+    /*
+     * example XHR handler
+    window.addEventListener('xhr', async ({detail}) => {
+        const {eventId, method, url, body, headers} = detail
+        const _headers = new Headers()
+
+        Object.entries(headers).forEach(([key, value]) => _headers.append(key, value))
+
+        const options = {
+            method,
+            headers: _headers
+        }
+
+        if(method == 'POST') options.body = body
+
+        const response = await fetch(url, options)
+
+        const status = response.status
+        const payload = await response.json()
+        const event = new CustomEvent(eventId, {detail: {status, payload}})
+
+        window.parent.document.dispatchEvent(event)
+    })
+    */
+
+    constructor() {
+        const id = this.id = genUid()
+        const element = this.element = document.createElement('IFRAME')
+        element.className = 'd-none'
+        element.src = `${XHR_JAIL_URL}?${id}`
+        document.body.appendChild(element)
+    }
+
+    dispatchEvent(event) {
+        this.element.contentWindow.dispatchEvent(event)
+    }
+
+    async doXhr(_method, url, body, headers) {
+        const method = _method.toUpperCase()
+        const eventId = genUid()
+
+        const event = new CustomEvent('xhr', {detail: {eventId, method, url, body: JSON.stringify(body), headers}})
+        ufsvIFrame.dispatchEvent(event)
+
+        let resolve, reject
+        const p = new Promise((_resolve, _reject) => { resolve = _resolve; reject = _reject; })
+
+        function handler ({detail}) {
+            if(detail.status >= 200 && detail.status <= 400){
+                resolve(detail.payload)
+            } else { reject(detail.payload) }
+            document.removeEventListener(eventId, handler)
+        }
+        document.addEventListener(eventId, handler)
+
+        const result = await p
+        return result
+    }
+}
+
+let ufsvIFrame
+if(unfurlServerUrlOverride()) { ufsvIFrame = new UnfurlServerIFrame() }
+
+async function doXhr(_method, url, body, headers) {
+    const method = _method.toUpperCase()
+    if(!['GET', 'POST'].includes(method)) throw new Error(`@doXhr: unexpected method for unfurl server "${method}"`)
+    if(!unfurlServerUrlOverride()) {
+        let response
+        if(method == 'GET') { response = await axios.get(url, {headers}) }
+        else if(method == 'POST') { response = await axios.post(url, body, {headers}) }
+
+        return response?.data
+    } else {
+        return await ufsvIFrame.doXhr(...arguments)
+    }
+
+}
+
+export async function unfurlServerExport({format, branch, projectPath, includeDeployments}) {
+    const baseUrl = unfurlServerUrlOverride() || DEFAULT_UNFURL_SERVER_URL
     const [lastCommitResult, password] = await Promise.all([fetchLastCommit(encodeURIComponent(projectPath), branch), fetchUserAccessToken()])
     const [latestCommit, _branch] = lastCommitResult
 
@@ -41,24 +122,25 @@ export async function unfurlServerExport({baseUrl, format, branch, projectPath, 
         exportUrl += '&include_all_deployments=1'
     }
 
-    const response = await axios.get(exportUrl, createConfig({includePasswordInQuery, username, password}))
-    return response.data
+    return await doXhr('GET', exportUrl, null, createHeaders({includePasswordInQuery, username, password}))//await axios.get(exportUrl, createConfig({includePasswordInQuery, username, password}))
 }
 
-export async function unfurlServerUpdate({baseUrl, method, projectPath, branch, patch, commitMessage, variables}) {
+export async function unfurlServerUpdate({method, projectPath, branch, patch, commitMessage, variables}) {
+    const baseUrl = unfurlServerUrlOverride() || DEFAULT_UNFURL_SERVER_URL
     const username = window.gon.current_username
     const password = await fetchUserAccessToken()
 
-    const {data} = await axios.post(
-        `${baseUrl}/${method}?auth_project=${encodeURIComponent(projectPath)}`,
-        {
+    const body = {
             ...variables,
             branch,
             patch,
             commit_msg: commitMessage || method
-        },
-        createConfig({username, password})
-    )
+    }
+    const headers = createHeaders({username, password})
+    headers['Content-Type'] = 'application/json'
+    const url = `${baseUrl}/${method}?auth_project=${encodeURIComponent(projectPath)}`
+
+    const data = await doXhr('POST', url, body, headers)
 
     if(data.commit) {
         setLastCommit(encodeURIComponent(projectPath), branch, data.commit)

--- a/packages/oc-pages/vue_shared/components/oc/experimental-settings-indicator.vue
+++ b/packages/oc-pages/vue_shared/components/oc/experimental-settings-indicator.vue
@@ -1,0 +1,106 @@
+<script>
+import {CONFIGURABLE_HIDDEN_OPTIONS, indicateExperimentalSetting, lookupKey, setLocalStorageKey, clearSettings} from '../../storage-keys'
+import {GlButton, GlIcon, GlModal} from '@gitlab/ui'
+import {Card as ElCard, Input as ElInput} from 'element-ui'
+import ErrorSmall from './ErrorSmall.vue'
+import {mapGetters} from 'vuex'
+export default {
+    name: 'ExperimentalSettingIndicator',
+    components: {GlButton, GlIcon, GlModal, ElInput, ErrorSmall},
+    data() {
+        return {
+            indicateExperimentalSetting: indicateExperimentalSetting(),
+            yPos: '0px',
+            xPos: '0px',
+            CONFIGURABLE_HIDDEN_OPTIONS,
+            valuesByKey: CONFIGURABLE_HIDDEN_OPTIONS.reduce((acc, option) => {acc[option.key] = lookupKey(option.key); return acc}, {}),
+            changed: false
+        }
+    },
+    methods: {
+        computePosition() {
+            const {y, height, x, width} = document.querySelector('[data-qa-selector="navbar"] .navbar-collapse.collapse').getBoundingClientRect()
+            this.yPos = y + 'px'
+            this.xPos = x + 'px'
+        },
+        lookupKey,
+        setLocalStorageKey,
+        clearSettings,
+    },
+    computed: {
+        ...mapGetters(['windowWidth']),
+        modal: {
+            get() {
+                return this.$route.query.hasOwnProperty('dev-settings')
+            },
+            set(val) {
+                if(!val && this.modal) {
+                    const newQuery = {...this.$route.query}
+                    delete newQuery['dev-settings']
+                    this.$router.replace({...this.$route, query: newQuery})
+                } else if(val && !this.modal) {
+                    const newQuery = {...this.$route.query}
+                    newQuery['dev-settings'] = null
+                    this.$router.push({...this.$route, query: newQuery})
+                }
+                this.valuesByKey = CONFIGURABLE_HIDDEN_OPTIONS.reduce((acc, option) => {acc[option.key] = lookupKey(option.key); return acc}, {})
+            }
+        },
+    },
+    watch: {
+        windowWidth: {
+            immediate: true,
+            handler(_) {
+                this.computePosition()
+            }
+        }
+    },
+    mounted() {
+        document.addEventListener('keyup', e => {
+            if(e.ctrlKey && e.key == '?') this.modal = true
+        })
+    }
+}
+</script>
+<template>
+    <div>
+        <gl-modal
+            title="Developer Settings"
+            modal-id="dev-settings-modal"
+            :action-primary="{text: 'OK', attributes: [{variant: 'info'}]}"
+            :action-secondary="{text: 'Restore Default Settings', attributes: [{variant: 'danger'}]}"
+            @secondary="clearSettings(); modal = false; indicateExperimentalSetting = false;"
+            v-model="modal"
+        >
+            <el-card class="settings-modal-body">
+                <el-input
+                    @input="v => {setLocalStorageKey(option.key, v); valuesByKey[option.key] = v; changed = true}"
+                    v-for="option in CONFIGURABLE_HIDDEN_OPTIONS"
+                    :key="option.key"
+                    :value="valuesByKey[option.key]"
+                    :placeholder="option.placeholder"
+                    :type="option.type || 'text'"
+                >
+                    <template slot="prepend"><span style="font-size: 12px;" class="text-monospace">{{option.label}}</span></template>
+                </el-input>
+                <error-small :condition="changed" message="Changes will be reflected after page refresh" />
+            </el-card>
+        </gl-modal>
+        <div class="position-fixed" style=" z-index: 1000; pointer-events: none;" :style="{left: xPos, top: yPos}">
+            <div v-if="indicateExperimentalSetting" class="d-inline-block position-relative" style="transform: translateX(-100%); pointer-events: all">
+                <!-- shameless sizes without calculations - this might get moved somewhere else so it fits better inline -->
+                <gl-button @click="modal = true" variant="confirm" style="height: 32px; margin-top: 4px;">
+                    <div class="d-flex align-items-center justify-content-between" style="padding-top: 2px;">
+                        <gl-icon :size="16" name="code" class="mr-1"/>
+                        <span style="font-size: 13px;">{{__('Developer settings enabled')}}</span>
+                    </div>
+                </gl-button>
+            </div>
+        </div>
+    </div>
+</template>
+<style scoped>
+.settings-modal-body >>> .el-input-group__prepend {
+    width: 250px;
+}
+</style>

--- a/packages/oc-pages/vue_shared/storage-keys.js
+++ b/packages/oc-pages/vue_shared/storage-keys.js
@@ -39,6 +39,9 @@ export function unfurlServerUrlOverride() {
     return lookupKey( HIDDEN_OPTION_KEYS.unfurlServerUrl )
 }
 
+export const XHR_JAIL_URL = '/-/crossorigin-xhr'
+export const DEFAULT_UNFURL_SERVER_URL = '/services/unfurl-server'
+
 window.lsHiddenOptions = function() {
     for(const opt of Object.values(HIDDEN_OPTION_KEYS)) console.log(opt)
 }

--- a/packages/oc-pages/vue_shared/storage-keys.js
+++ b/packages/oc-pages/vue_shared/storage-keys.js
@@ -77,7 +77,7 @@ export function indicateExperimentalSetting() {
     return unfurlServerUrlOverride() || shouldConnectWithoutCopy() || alwaysSendLatestCommit()
 }
 
-export const XHR_JAIL_URL = '/-/crossorigin-xhr'
+export const XHR_JAIL_URL = '/oc/assets/-/crossorigin-xhr'
 export const DEFAULT_UNFURL_SERVER_URL = '/services/unfurl-server'
 
 window.lsHiddenOptions = function() {

--- a/scripts/src/integration-test.js
+++ b/scripts/src/integration-test.js
@@ -73,6 +73,7 @@ const FORWARD_ENVIRONMENT_VARIABLES = [
   'MAIL_USERNAME', 'MAIL_PASSWORD', 'SMTP_HOST', 'MAIL_RESOURCE_NAME',
   'DEPLOY_IMAGE', 'DEPLOY_TAG',
   'TEARDOWN', 'GENERATE_SUBDOMAINS', // used in recreate deployment
+  'UNFURL_SERVER_URL', // session storage vars
 ]
 
 


### PR DESCRIPTION
Currently hardcoded to load the i-frame from ` /-/crossorigin-xhr`
I used this location block to support CORS
```nginx
    location /services/unfurl-server {
      if ($request_method ~* "(GET|POST)") {
        add_header "Access-Control-Allow-Origin" * always;
      }
      if ($request_method = 'OPTIONS') {
        add_header 'Access-Control-Allow-Origin' '*';
        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, HEAD';
        add_header 'Access-Control-Allow-Headers' 'x-git-credentials, content-type, accept';

        return 200;
      }

      proxy_pass http://localhost:8081/;
    }
```

This commit has a comment containing an example script for the i-frame that I tested this with.