### PR TITLE
Make default deployment name more descriptive

### DIFF
--- a/packages/oc-pages/project_overview/pages/projects/index.vue
+++ b/packages/oc-pages/project_overview/pages/projects/index.vue
@@ -16,6 +16,7 @@ import { bus } from 'oc_vue_shared/bus';
 import { slugify, lookupCloudProviderAlias, USER_HOME_PROJECT } from 'oc_vue_shared/util.mjs'
 import {deleteEnvironmentByName} from 'oc_vue_shared/client_utils/environments'
 import {fetchProjectPermissions} from 'oc_vue_shared/client_utils/projects'
+import {lookupCloudProviderShortName} from 'oc_vue_shared/util.mjs'
 import { createDeploymentTemplate } from '../../store/modules/deployment_template_updates.js'
 import * as routes from '../../router/constants'
 
@@ -177,7 +178,7 @@ export default {
         },
         templateSelected: function(val) {
             if(this.templateForkedName) return
-            if(val && this.instantiateAs == 'deployment-draft') this.templateForkedName = this.getNextDefaultDeploymentName(val.title)
+            if(val && this.instantiateAs == 'deployment-draft') this.templateForkedName = this.getNextDefaultDeploymentName(this.getApplicationBlueprint.title + ' ' + lookupCloudProviderShortName(val.cloud))
             else this.templateForkedName = ''
 
         },

--- a/packages/oc-pages/vue_shared/util.mjs
+++ b/packages/oc-pages/vue_shared/util.mjs
@@ -49,6 +49,17 @@ export function lookupCloudProviderAlias(key) {
   return result
 }
 
+export function lookupCloudProviderShortName(key) {
+  const actual = lookupCloudProviderAlias(key)
+  const dict = {
+    [GCP]: 'GCP',
+    [AWS]: 'AWS',
+    [K8s]: 'K8s',
+    [Azure]: 'Azure',
+    [DigitalOcean]: 'DO'
+  }
+  return dict[actual]
+}
 
 export function cloudProviderFriendlyName(key) {
     const actual = lookupCloudProviderAlias(key)


### PR DESCRIPTION
Deployment names have a scheme of `<blueprint-title> <provider> <n>` where provider is abbreviated (GCP, AWS, etc.)
https://github.com/onecommons/gitlab-oc/issues/1401