### PR TITLE
Use fake password for formily

### DIFF
--- a/packages/oc-pages/project_overview/components/shared/oc_inputs.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_inputs.vue
@@ -4,11 +4,11 @@ import {bus} from 'oc_vue_shared/bus';
 import {__} from '~/locale';
 import {mapActions, mapMutations, mapGetters} from 'vuex'
 import {FormProvider, createSchemaField} from "@formily/vue";
-import {FormLayout, FormItem, ArrayItems, Input, InputNumber, Checkbox, Select, Password, Editable, Space} from "@formily/element";
+import {FormLayout, FormItem, ArrayItems, Input, InputNumber, Checkbox, Select, Editable, Space} from "@formily/element";
 import {Card as ElCard} from 'element-ui'
 import {createForm, onFieldInputValueChange} from "@formily/core";
 import {resolverName, tryResolveDirective} from 'oc_vue_shared/lib'
-import {getCustomTooltip, getUiDirective} from './oc_inputs'
+import {FakePassword, getCustomTooltip, getUiDirective} from './oc_inputs'
 
 
 const ComponentMap = {
@@ -18,7 +18,7 @@ const ComponentMap = {
   enum: 'Select',
   object: 'Editable.Popover',
   array: 'ArrayItems',
-  password: 'Password',
+  password: FakePassword,
 };
 
 const fields = createSchemaField({
@@ -27,7 +27,7 @@ const fields = createSchemaField({
     ArrayItems,
     Space,
     Input,
-    InputNumber, Checkbox, Select, Password, Editable
+    InputNumber, Checkbox, Select, FakePassword, Editable
   }
 })
 

--- a/packages/oc-pages/project_overview/components/shared/oc_inputs/fake-password.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_inputs/fake-password.vue
@@ -1,0 +1,50 @@
+<script>
+import {Input as ElInput} from 'element-ui'
+
+export default {
+    name: 'FakePassword',
+    components: {
+        ElInput
+    },
+    props: {
+        value: String
+    },
+    data() {
+        return {
+            hidingPassword: true,
+        }
+    },
+    methods: {
+        input() {
+            this.$emit('input', ...arguments)
+        }
+    }
+}
+</script>
+<template>
+    <el-input
+        ref="input-el"
+        :value="value"
+        @input="input"
+        :class="{hidingPassword}"
+        type="text"
+    >
+        <template #suffix>
+            <i @click="hidingPassword = !hidingPassword" class="el-input__icon el-icon-view el-input__clear" />
+        </template>
+    </el-input>
+</template>
+<style>
+    @font-face {
+        font-family: 'Password';
+        font-style: normal;
+        font-weight: 400;
+        src: url(/oc/assets/fonts/Bullets.woff2) format('woff2');
+    }
+
+    .hidingPassword input {
+        letter-spacing: 0.5px;
+        padding-top: 4px;
+        font-family: Password;
+    }
+</style>

--- a/packages/oc-pages/project_overview/components/shared/oc_inputs/formily-fake-password.js
+++ b/packages/oc-pages/project_overview/components/shared/oc_inputs/formily-fake-password.js
@@ -1,0 +1,19 @@
+import { Input, PreviewText } from '@formily/element'
+import { connect, mapProps, mapReadPretty } from '@formily/vue'
+import { composeExport, transformComponent } from '@formily/element/lib/__builtins__/shared'
+
+import FakePassword from './fake-password.vue'
+
+const TransformFakePassword = transformComponent(FakePassword, {
+    change: 'input'
+})
+
+const InnerInput = connect(
+  TransformFakePassword,
+  mapProps({ readOnly: 'readonly' }),
+  mapReadPretty(PreviewText.Input)
+)
+
+export const Password = composeExport(InnerInput)
+
+export default Password

--- a/packages/oc-pages/project_overview/components/shared/oc_inputs/index.js
+++ b/packages/oc-pages/project_overview/components/shared/oc_inputs/index.js
@@ -33,3 +33,5 @@ export function getCustomTooltip(type) {
 export function getUiDirective(type) {
     return uiDirectives[type] ?? null
 }
+
+export {default as FakePassword} from './formily-fake-password'


### PR DESCRIPTION
This currently does not prevent the user from copying the mock password element's value

Requires https://github.com/onecommons/gitlab-oc/pull/1438