### PR TITLE
Fixes for local blueprint dev

### DIFF
--- a/packages/oc-pages/project_overview/components/local-develop.vue
+++ b/packages/oc-pages/project_overview/components/local-develop.vue
@@ -34,7 +34,7 @@ export default {
         </p>
         <p>
             Clone this Unfurl project if you haven't already:
-            <code-clipboard class="mt-2">git clone '{{cloneURL}}'</code-clipboard>
+            <code-clipboard class="mt-2">unfurl clone --design '{{cloneURL}}'</code-clipboard>
             (Or if you have, run "git pull" to get latest.)
         </p>
         <p>

--- a/packages/oc-pages/project_overview/pages/projects/index.vue
+++ b/packages/oc-pages/project_overview/pages/projects/index.vue
@@ -150,7 +150,7 @@ export default {
         },
 
         activeTab() {
-            const {availableBlueprintsTab, openCloudDeploymentsTab, yourDeploymentsTab, commentsTab} = this.$refs
+            const {availableBlueprintsTab, developmentTab, openCloudDeploymentsTab, yourDeploymentsTab, commentsTab} = this.$refs
             if(availableBlueprintsTab?.active) return 'availableBlueprintsTab'
             if(developmentTab?.active) return 'developmentTab'
             if(openCloudDeploymentsTab?.active) return 'openCloudDeploymentsTab'

--- a/packages/oc-pages/project_overview/router/index.js
+++ b/packages/oc-pages/project_overview/router/index.js
@@ -56,8 +56,8 @@ export default function createRouter(base) {
     })
 
     router.afterEach(to => {
-        if(to.query.hasOwnProperty('unfurl-server-url')) {
-            const devUrl = to.query['unfurl-server-url']
+        if(to.query.hasOwnProperty('unfurl-server-url') || to.query.hasOwnProperty('unfurl-server')) {
+            const devUrl = to.query['unfurl-server-url'] || to.query['unfurl-server']
             if(devUrl) {
                 setLocalStorageKey(HIDDEN_OPTION_KEYS.unfurlServerUrlDev, {project: base, url: devUrl})
             } else {
@@ -70,7 +70,7 @@ export default function createRouter(base) {
         const url = unfurlServerUrlDev(base)
 
         if(developmentMode) {
-            const newRoute = router.resolve({...to, query: {...to.query, 'unfurl-server-url': ''}}).href
+            const newRoute = router.resolve({...to, query: {...to.query, 'unfurl-server-url': '', 'unfurl-server': undefined}}).href
             const message =  `Developing with Unfurl Server on ${url}`
             const linkTo = newRoute
             const linkTarget = '_self'

--- a/packages/oc-pages/vue_shared/storage-keys.js
+++ b/packages/oc-pages/vue_shared/storage-keys.js
@@ -90,12 +90,12 @@ export function unfurlServerUrlDev(currentProject) {
         let {project, url} = JSON.parse(setting)
         if(!project || project != currentProject) return
         if(url.startsWith('localhost')) {
-            try {
-                url = new URL(`http://${url}`)
-                return url.toString()
-            } catch(e) {
-                console.error(e)
-            }
+            url += 'localhost'
+        }
+        try {
+            return (new URL(url)).toString()
+        } catch(e) {
+            console.error(e)
         }
     }
 }


### PR DESCRIPTION
- Don't crash on pages with discussions
- Use `unfurl clone --design`
- More robust acceptance for ?unfurl-server-url (and ?unfurl-server)