### PR TITLE
Additional autostop acceptance criteria

### DIFF
--- a/packages/oc-pages/dashboard/components/cells/deployment-controls/open-live-app.vue
+++ b/packages/oc-pages/dashboard/components/cells/deployment-controls/open-live-app.vue
@@ -17,16 +17,20 @@ export default {
             if(typeof this.pollingStatus != 'function') return false
             const pollingStatus = this.pollingStatus(this.deployment?.name)
             return pollingStatus == 'PENDING'
+        },
+        title() {
+            if(this.disabled) {
+                return 'Application is not currently reachable'
+            }
         }
-
     }
 }
 </script>
 <template>
-    <component :is="component" :disabled="disabled" target="_blank" rel="noopener noreferrer" :href ="deployment.url" variant="confirm">
+    <component :is="component" v-gl-tooltip.hover :title="title" :disabled="disabled" target="_blank" rel="noopener noreferrer" :href ="deployment.url" variant="confirm">
 
-        <gl-loading-icon v-if="disabled" class="mr-1"/>
-        <gl-icon v-else :size="16" name="external-link"/> 
+        <gl-loading-icon v-if="disabled && component != 'gl-dropdown-item'" class="mr-1"/>
+        <gl-icon v-else :size="16" name="external-link"/>
         {{__('Open Live App')}}
     </component>
 </template>

--- a/packages/oc-pages/dashboard/components/tables/deployment-index-table.vue
+++ b/packages/oc-pages/dashboard/components/tables/deployment-index-table.vue
@@ -54,6 +54,12 @@ const tabFilters = [
         filter(item) { return false }
     },
     {
+        title: 'Autostop Scheduled',
+        filter(item) {
+            return item.autostopScheduled
+        }
+    },
+    {
         title: 'Failed',
         filter(item) {
             return (
@@ -65,7 +71,7 @@ const tabFilters = [
     {
         title: 'Destroyed',
         filter(item) { return item.isUndeployed }
-    }
+    },
 ]
 
 export default {
@@ -229,6 +235,7 @@ export default {
         async onModalConfirmed() {
             const intent = this.intent
             const {deployment, environment} = this.target
+            const deploymentItem = this.deploymentItemDirect({deployment, environment})
 
             await Vue.nextTick() // wait until modal is closed before doing anything
 
@@ -239,6 +246,9 @@ export default {
                     if(! this.hasCriticalErrors) window.location.reload()
                     return
                 case 'undeploy':
+                    if(deploymentItem.isAutostopCancelable) {
+                        await deploymentItem.cancelAutostop()
+                    }
                     this.undeploy()
                     return
                 case 'deploy':
@@ -272,7 +282,6 @@ export default {
                     window.location.href = redirectLocation
                     return
                 case 'incRedeploy':
-                    const deploymentItem = this.deploymentItemDirect({deployment, environment})
                     const variables = deploymentItem.pipeline.variables
                     const upstreamBranch = deploymentItem.pipeline.upstream_branch
                     const upstreamCommit = deploymentItem.pipeline.upstream_commit_id

--- a/packages/oc-pages/dashboard/store/modules/deployment-info/deployment-item.js
+++ b/packages/oc-pages/dashboard/store/modules/deployment-info/deployment-item.js
@@ -148,7 +148,7 @@ export default class DeploymentItem {
 
 
     get autostopScheduled() {
-        return this.autostopJob && new Date(this.autostopJob.scheduledAt)
+        return this.autostopJob?.status == 'SCHEDULED' && new Date(this.autostopJob.scheduledAt)
     }
     get isAutostopCancelable() {
         return this.autostopJob?.status == 'SCHEDULED'


### PR DESCRIPTION
- Add autostop countdown timer to deployment view primary card
- Cancel autostop pipeline on early teardown
- Add "Autostop Scheduled" category to dashboard/-/deployments filter

One criteria from yesterday's standup did not require any code change:
- surface "cancel autostop" menu item on top

The following was implemented in the previous commit:
- cancel upcoming job so it show the previous deployment log in the console tab
