### PR TITLE
Fix shared resource display regressions

### DIFF
--- a/packages/oc-pages/dashboard/components/share-resource-toggle.vue
+++ b/packages/oc-pages/dashboard/components/share-resource-toggle.vue
@@ -38,14 +38,15 @@ export default {
              * https://github.com/onecommons/gitlab-oc/issues/1167
             */
             // const type = this.resolveResourceTypeFromAny(this.card?.type)
+            if(!this.card) return false
 
             return (
                 // type?.implementations?.includes('connect') &&
                 this.userCanEdit &&
-                this.card?.name &&
-                !(this.card?.status == 3 || this.card?.status == 5) && // status is not error or absent
-                this.card?.__typename != 'ResourceTemplate' &&
-                !this.card.name.startsWith('__') // __ prefix is a hack for unfurl-gui to track external resources
+                this.card.name &&
+                !(this.card.status == 3 || this.card?.status == 5) && // status is not error or absent
+                this.card.__typename != 'ResourceTemplate' &&
+                !this.card._external
                 // && this.card.status == 1 // require OK status
             )
         },

--- a/packages/oc-pages/dashboard/pages/environment.vue
+++ b/packages/oc-pages/dashboard/pages/environment.vue
@@ -156,7 +156,7 @@ export default {
     methods: {
         ...mapActions([
             'useProjectState',
-            'populateTemplateResources2',
+            'populateEnvironmentResources',
             'createNodeResource',
             'commitPreparedMutations',
             'normalizeUnfurlData',
@@ -300,7 +300,7 @@ export default {
             )
             // TODO implement and test normalization for connections - this should account better for users making manual changes
 
-            this.populateTemplateResources2({
+            await this.populateEnvironmentResources({
                 resourceTemplates: [
                     ...instances,
                     ...connections

--- a/packages/oc-pages/project_overview/components/shared/oc_card.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_card.vue
@@ -7,6 +7,7 @@ import StatusIcon from 'oc_vue_shared/components/oc/Status.vue'
 import {DetectIcon} from 'oc_vue_shared/components/oc'
 import {generateCardId} from 'oc_vue_shared/util'
 import {Tooltip as ElTooltip} from 'element-ui'
+import templateMixin from './template-mixin'
 
 import { __ } from '~/locale';
 
@@ -24,7 +25,7 @@ export default {
         DetectIcon,
         ElTooltip
     },
-    mixins: [commonMethods],
+    mixins: [templateMixin, commonMethods],
     props: {
         isPrimary: {
             type: Boolean,
@@ -161,29 +162,6 @@ export default {
 
         _displayStatus() {
             return this.displayStatus || this._readonly
-        },
-
-        importedResource() {
-            if(!this.card?.imported) return null
-            const [deploymentName, resourceName] = this.card.imported.split(':', 2)
-            const deployment = deploymentName?
-                this.getDeployments.find(dep => dep.name == deploymentName) :
-                this.getDeployment
-
-            if(!deployment) return null
-
-            const dict = this.getDeploymentDictionary(deployment.name, deployment._environment)
-            const resource = dict['Resource'][resourceName]
-
-            // resolve the template here, since it's not in our other dictionary
-            return {...resource, template: dict['ResourceTemplate'][resource.template]}
-        },
-
-        _card() {
-            if(this.importedResource) {
-                return {...this.card, ...this.importedResource, imported: this.card.imported}
-            }
-            return this.card
         },
 
         childAttrs() {

--- a/packages/oc-pages/project_overview/components/shared/oc_card.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_card.vue
@@ -75,7 +75,8 @@ export default {
             type: Array,
             required: false,
             default: null
-        }
+        },
+        removable: Boolean
     },
     data() {
         return {
@@ -142,6 +143,18 @@ export default {
             return this.readonly || this.card?.imported || this.card?.readonly
         },
 
+        canRemove() {
+            const card = this._card
+            if(!card) return false
+            if(this.removable) return true
+            return (
+                !this.isPrimary &&
+                !this._readonly &&
+                !card._permanent &&
+                !card._deployed
+            )
+        },
+
         _displayValidation() {
             return this.displayValidation && ! this._readonly
         },
@@ -185,6 +198,20 @@ export default {
 
         _children() {
             return this.children ?? this.getCardsInTopology(this.card.name)
+        },
+
+        deleteAction() {
+            if(this._readonly) {
+                return 'Disconnect'
+            }
+            return 'Delete'
+        },
+
+        removeButtonText() {
+            if(this._readonly) {
+                return 'Disconnect'
+            }
+            return 'Remove'
         }
     },
     methods: {
@@ -193,9 +220,9 @@ export default {
             this.$emit('deleteNode', ...args)
         },
 
-        openDeletemodal(title, action=__("Delete")) {
+        openDeletemodal() {
             // eslint-disable-next-line no-unused-expressions
-            const payload = {...this.card, action}
+            const payload = {...this.card, action: this.deleteAction}
             // TODO get rid of bus
             bus.$emit('deleteNode', payload);
 
@@ -261,10 +288,10 @@ export default {
                     </slot>
                     <div class="d-flex align-items-center">
                         <slot name="controls" v-bind="card">
-                            <gl-button v-if="card && !isPrimary && !_readonly && !card._permanent && !card._deployed" @click="openDeletemodal" class="controls">
+                            <gl-button v-if="canRemove" @click="openDeletemodal" class="controls">
                                 <div class="d-flex align-items-center">
                                     <gl-icon name="remove" />
-                                    <div> {{__('Remove')}} </div>
+                                    <div> {{__(removeButtonText)}} </div>
                                 </div>
                             </gl-button>
 

--- a/packages/oc-pages/project_overview/components/shared/oc_list.vue
+++ b/packages/oc-pages/project_overview/components/shared/oc_list.vue
@@ -7,6 +7,7 @@ import commonMethods from '../mixins/commonMethods';
 import { mapGetters } from 'vuex'
 import Dependency from './dependency.vue'
 import {getCustomInputComponent} from './oc_inputs'
+import templateMixin from './template-mixin'
 
 export default {
     name: 'OcList',
@@ -16,7 +17,7 @@ export default {
         Dependency,
     },
 
-    mixins: [commonMethods],
+    mixins: [templateMixin, commonMethods],
 
     props: {
         tabsTitle: {
@@ -144,8 +145,8 @@ export default {
 
             const schema = {
                 ...this.inputsSchema?.properties,
-                ...resourceType.outputsSchema?.properties,
-                ...resourceType.computedPropertiesSchema?.properties
+                ...resourceType?.outputsSchema?.properties,
+                ...resourceType?.computedPropertiesSchema?.properties
             }
 
             const consoleURLIndex = attributes.findIndex(a => a.name == 'console_url')
@@ -238,28 +239,6 @@ export default {
                 }
             }
             return result
-        },
-        importedResource() {
-            if(!this.card?.imported) return null
-            const [deploymentName, resourceName] = this.card.imported.split(':', 2)
-            const deployment = deploymentName?
-                this.getDeployments.find(dep => dep.name == deploymentName) :
-                this.getDeployment
-
-            if(!deployment) return null
-
-            const dict = this.getDeploymentDictionary(deployment.name, deployment._environment)
-            const resource = dict['Resource'][resourceName]
-
-            // resolve the template here, since it's not in our other dictionary
-            return {...resource, template: dict['ResourceTemplate'][resource.template]}
-        },
-
-        _card() {
-            if(this.importedResource) {
-                return {...this.card, ...this.importedResource, imported: this.card.imported}
-            }
-            return this.card
         },
 
         inputsTitleCount() {

--- a/packages/oc-pages/project_overview/components/shared/template-mixin.js
+++ b/packages/oc-pages/project_overview/components/shared/template-mixin.js
@@ -1,0 +1,28 @@
+export default {
+    computed: {
+        importedResource() {
+            if(!this.card?.imported) return null
+            let [deploymentName, ...resourceName] = this.card.imported.split(':')
+            resourceName = resourceName.join(':')
+            const deployment = deploymentName?
+                this.getDeployments.find(dep => dep.name == deploymentName) :
+                this.getDeployment
+
+            if(!deployment) return null
+
+            const dict = this.getDeploymentDictionary(deployment.name, deployment._environment)
+            const resource = dict['Resource'][resourceName]
+
+            // resolve the template here, since it's not in our other dictionary
+            return {...resource, template: dict['ResourceTemplate'][resource.template]}
+        },
+
+        _card() {
+            if(this.importedResource) {
+                return {...this.card, ...this.importedResource, imported: this.card.imported}
+            }
+            return this.card
+        },
+
+    }
+}

--- a/packages/oc-pages/project_overview/pages/templates/index.vue
+++ b/packages/oc-pages/project_overview/pages/templates/index.vue
@@ -909,6 +909,7 @@ export default {
                   :actions="true"
                   :level="idx"
                   :children="[]"
+                  removable
                   class="gl-mt-6">
                   <template #content>
                     <!--oc-inputs :card="card" :main-inputs="card.properties" :component-key="2" /-->

--- a/packages/oc-pages/project_overview/pages/templates/index.vue
+++ b/packages/oc-pages/project_overview/pages/templates/index.vue
@@ -968,7 +968,7 @@ export default {
             @cancel="cleanModalResource"
             >
 
-          <oc-list-resource @input="e => selected = e" v-model="selected" :name-of-resource="getNameResourceModal" :filtered-resource-by-type="[]" :deployment-template="getDeploymentTemplate" :cloud="getDeploymentTemplate.cloud" :valid-resource-types="validResourceTypesForSelectedRequirement" :resourceType="getRequirementResourceType"/>
+          <oc-list-resource @input="e => selected = e" v-model="selected" :filtered-resource-by-type="[]" :deployment-template="getDeploymentTemplate" :cloud="getDeploymentTemplate.cloud" :valid-resource-types="validResourceTypesForSelectedRequirement" :resourceType="getRequirementResourceType"/>
 
             <gl-form-group label="Name" class="col-md-4 align_left gl-pl-0 gl-mt-4">
               <gl-form-input id="input1" data-testid="create-resource-template-title" @input="_ => userEditedResourceName = true" v-model="resourceName" type="text"  /><small v-if="alertNameExists" class="alert-input">{{ __("The name can't be replicated. please edit the name!") }}</small>
@@ -1002,7 +1002,7 @@ export default {
         :action-cancel="cancelProps"
         @primary="onSubmitModalConnect"
       >
-        <oc-list-resource v-model="selectedServiceToConnect" :name-of-resource="getNameResourceModal" :filtered-resource-by-type="[]" :cloud="getDeploymentTemplate.cloud" :valid-resource-types="validConnections"/>
+        <oc-list-resource v-model="selectedServiceToConnect" :filtered-resource-by-type="[]" :cloud="getDeploymentTemplate.cloud" :valid-resource-types="validConnections"/>
       </gl-modal>
 
       <!-- Modal to confirm the action to delete template -->

--- a/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
+++ b/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
@@ -187,7 +187,7 @@ Serializers = {
         if(rt.__typename == 'Resource') return Serializers.Resource(rt)
 
         if(rt.directives?.includes('select')) {
-            allowFields(rt, 'name', 'title', 'directives', 'imported', 'type')
+            allowFields(rt, 'name', 'title', 'directives', 'imported', 'type', 'extends', 'metadata')
             return
         }
 
@@ -247,6 +247,8 @@ Serializers = {
 
         const newObject = {
             name: resource.name,
+            extends: resource.extends,
+            metadata: resource.metadata,
             title: resource.title,
             directives: ['select'],
             imported: `${resource._deployment}:${resource.template}`,
@@ -793,7 +795,7 @@ const getters = {
     hasPreparedMutations(state) { return state.preparedMutations.length > (state.effectiveFirstMutation || 0) },
     safeToNavigateAway(state, getters) { return !getters.hasPreparedMutations && !state.isCommitting},
     isCommittedName(state) { return function(typename, name) {return state.committedNames.includes(`${typename}.${name}`)}},
-
+    getCommitBranch(state) { return state.branch || 'main'}
 }
 
 const mutations = {

--- a/packages/oc-pages/project_overview/store/modules/deployments.js
+++ b/packages/oc-pages/project_overview/store/modules/deployments.js
@@ -295,6 +295,9 @@ const actions = {
 
         const newObject = {
             name: `__${environmentName}__${deploymentName}__${resourceName}`,
+            metadata: {
+                extends: rootGetters.resolveResourceTypeFromAny(resource.type)?.extends || [],
+            },
             title: resource.title,
             directives: ['select'],
             imported: `${deploymentName}:${resource.name}`,
@@ -321,6 +324,9 @@ const actions = {
         const name = `__${environmentName}__${deploymentName}__${resourceName}`
         const newObject = {
             name,
+            metadata: {
+                extends: rootGetters.resolveResourceTypeFromAny(resource.type)?.extends || [],
+            },
             title: resource.title,
             directives: ['select'],
             imported: `${deploymentName}:${resource.name}`,
@@ -597,6 +603,20 @@ const getters = {
                 .filter(r => getters.getResourceSharedState(environmentName, deploymentName, r.name))
         }
     },
+    getSharedResource(_, getters) {
+        return function(deploymentName, environmentName, resourceName) {
+            const dictionary = getters.getDeploymentDictionary(deploymentName, environmentName)
+            return Object.values(dictionary.Resource)
+                .find(r => r.name == resourceName)
+        }
+    },
+    getSharedResourceTemplate(_, getters) {
+        return function(deploymentName, environmentName, templateName) {
+            const dictionary = getters.getDeploymentDictionary(deploymentName, environmentName)
+            return Object.values(dictionary.ResourceTemplate)
+                .find(r => r.name == templateName)
+        }
+    },
 
     deleteDeploymentPreventedBy(_, getters) {
         return function(deploymentName, environmentName) {
@@ -621,6 +641,20 @@ const getters = {
             return result
         }
     },
+    getEnvironmentForDeployment(state, _a, _b, rootGetters) {
+        return function(deploymentName, preferEnvironment) {
+            const paths = rootGetters.allDeploymentPaths
+            let result
+            if(preferEnvironment) {
+                result = paths.find(p => p.name.endsWith(`/${deploymentName}`) && p.environment == preferEnvironment)
+            }
+            if(!result) {
+                result = paths.find(p => p.name.endsWith(`/${deploymentName}`))
+            }
+
+            return result.environment
+        }
+    }
 };
 
 

--- a/packages/oc-pages/project_overview/store/modules/environments.js
+++ b/packages/oc-pages/project_overview/store/modules/environments.js
@@ -663,8 +663,11 @@ const getters = {
         if(!environment) return []
         let result = []
         if(environment.instances) result = Object.values(environment.instances).filter(conn => {
-            const cextends = getters.environmentResolveResourceType(environmentName, conn.type)?.extends
-            return cextends && cextends.includes(constraintType)
+            const connExtends = [
+                ...(getters.environmentResolveResourceType(environmentName, conn.type)?.extends || []),
+                ...(conn.metadata?.extends || [])
+            ]
+            return connExtends?.includes(constraintType)
         })
 
         /*
@@ -862,6 +865,10 @@ const getters = {
             ]
 
         }
+    },
+
+    allDeploymentPaths(state) {
+        return Object.freeze(state.deploymentPaths)
     }
 };
 

--- a/packages/oc-pages/project_overview/store/modules/project_application_blueprint.js
+++ b/packages/oc-pages/project_overview/store/modules/project_application_blueprint.js
@@ -253,7 +253,7 @@ const actions = {
                 deployment.projectPath = dt?.projectPath
             },
             DeploymentEnvironment(de, root) {
-                for(const connection of Object.values(de.connections)) {
+                for(const connection of Object.values(de.connections || {})) {
                     if(!root.ResourceTemplate) { root.ResourceTemplate = {} }
 
                     // intentionally not cloning


### PR DESCRIPTION
- Dynamically fetch deployments as needed for imported templates
- Insert metadata.extends into imported/pointer templates for connect
  typing information
- Handle outputs schema not available for shared resource in deployment view
- Consolidate methods for creating template list

Tangentially related
- Refactor to make external resource copy optional again