### PR TITLE
Support recursively copying templates from nested topologies of substitute nodes

### DIFF
--- a/packages/oc-pages/project_overview/components/shared/dependency.vue
+++ b/packages/oc-pages/project_overview/components/shared/dependency.vue
@@ -237,7 +237,7 @@ export default {
                     title="create"
                     :aria-label="__(`create`)"
                     type="button"
-                    :data-testid="`create-dependency-${card.name}.${dependency.name}`"
+                    :data-testid="`create-dependency-${card._unmangled || card.name}.${dependency.name}`"
                     class="gl-ml-3 oc_requirements_actions"
                     @click="sendRequirement(dependency)">{{ __('Create') }}</gl-button>
             </div>

--- a/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
+++ b/packages/oc-pages/project_overview/store/modules/deployment_template_updates.js
@@ -239,7 +239,7 @@ Serializers = {
             rt.dependencies = rt.dependencies.filter(
                 dep => !(
                     rt.dependencies.some(otherDep => otherDep.name == dep.match) &&
-                    !state.ResourceTemplate[rt.match]
+                    !state.ResourceTemplate[dep.match]
                 )
             )
         }

--- a/packages/oc-pages/project_overview/store/modules/project_application_blueprint.js
+++ b/packages/oc-pages/project_overview/store/modules/project_application_blueprint.js
@@ -406,10 +406,6 @@ const actions = {
         )
 
 
-        for(const nestedTemplate of Object.values(nestedTemplatesByPrimary).map(Object.values).flat()) {
-            dispatch('normalizeUnfurlData', {key: 'ResourceTemplate', entry: nestedTemplate, root: {ResourceType: types}})
-        }
-
         commit('setProjectState', {key: "nestedTemplatesByPrimary", value: {...state.nestedTemplatesByPrimary, ...nestedTemplatesByPrimary}})
     }
 }

--- a/packages/oc-pages/vue_shared/client_utils/unfurl-server.js
+++ b/packages/oc-pages/vue_shared/client_utils/unfurl-server.js
@@ -246,7 +246,14 @@ function groupTemplatesByPrimary(typesExportDict) {
 
         if(primary.directives.includes('substitute')) {
             return {
-                [primary.name]: typesExportDict.ResourceTemplate
+                [primary.name]: {
+                    shared: typesExportDict.ResourceTemplate,
+                    local: _.mapValues( // dict with cloud provider types => local templates
+                        _.mapKeys( // does not account for multiple deployment templates per cloud
+                            typesExportDict.DeploymentTemplate,
+                            value => value.cloud
+                        ),  dt => (dt.ResourceTemplate || {}))
+                }
             }
         }
 


### PR DESCRIPTION
Passed all dryruns w/ v2 dashboard (v1 + v2 blueprints) after modifying cypress tests to account for different naming conventions